### PR TITLE
feat: automatically delete expired leave records daily

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -124,12 +124,13 @@ func NewServer(db *database.DB, development bool) (*Server, error) {
 }
 
 func (s *Server) setupSessionCleanup(ctx context.Context) {
+	cleanupCtx, cleanupCancel := context.WithCancel(ctx)
+	s.cleanupCtx = cleanupCtx
+	s.cleanupCancel = cleanupCancel
+
 	// Start session cleanup background task (only if auth is enabled)
 	if s.sessionManager != nil {
 		log.Println("Starting session cleanup task...")
-		cleanupCtx, cleanupCancel := context.WithCancel(ctx)
-		s.cleanupCtx = cleanupCtx
-		s.cleanupCancel = cleanupCancel
 		//nolint:contextcheck // Cleanup context is properly managed and canceled in StopCleanup
 		s.sessionManager.StartCleanup(s.cleanupCtx)
 	} else {
@@ -138,22 +139,22 @@ func (s *Server) setupSessionCleanup(ctx context.Context) {
 }
 
 // startLeaveCleanup starts a background goroutine that deletes expired leave records daily.
-func (s *Server) startLeaveCleanup(ctx context.Context) {
+func (s *Server) startLeaveCleanup() {
 	log.Println("Starting leave record cleanup task...")
 	ticker := time.NewTicker(leaveCleanupInterval)
 	go func() {
 		defer ticker.Stop()
 		// Run immediately on start.
-		if err := s.db.DeleteExpiredLeaveRecords(ctx); err != nil {
+		if err := s.db.DeleteExpiredLeaveRecords(s.cleanupCtx); err != nil {
 			log.Printf("Leave cleanup error: %v\n", err)
 		}
 		for {
 			select {
 			case <-ticker.C:
-				if err := s.db.DeleteExpiredLeaveRecords(ctx); err != nil {
+				if err := s.db.DeleteExpiredLeaveRecords(s.cleanupCtx); err != nil {
 					log.Printf("Leave cleanup error: %v\n", err)
 				}
-			case <-ctx.Done():
+			case <-s.cleanupCtx.Done():
 				return
 			}
 		}
@@ -191,7 +192,8 @@ func (s *Server) stopCleanup() {
 
 func (s *Server) Start(ctx context.Context, port string) error {
 	s.setupSessionCleanup(ctx)
-	s.startLeaveCleanup(ctx)
+	s.startLeaveCleanup()
+	defer s.stopCleanup()
 
 	// Use http.Server with timeouts for production
 	srv := &http.Server{

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -32,7 +32,8 @@ const (
 	serverReadTimeout      = 15 * time.Second
 	serverWriteTimeout     = 15 * time.Second
 	serverIdleTimeout      = 60 * time.Second
-	sessionCleanupInterval = 1 * time.Hour // Clean up expired sessions every hour
+	sessionCleanupInterval = 1 * time.Hour  // Clean up expired sessions every hour.
+	leaveCleanupInterval   = 24 * time.Hour // Clean up expired leave records once a day.
 	shutdownTimeout        = 30 * time.Second
 )
 
@@ -136,6 +137,29 @@ func (s *Server) setupSessionCleanup(ctx context.Context) {
 	}
 }
 
+// startLeaveCleanup starts a background goroutine that deletes expired leave records daily.
+func (s *Server) startLeaveCleanup(ctx context.Context) {
+	log.Println("Starting leave record cleanup task...")
+	ticker := time.NewTicker(leaveCleanupInterval)
+	go func() {
+		defer ticker.Stop()
+		// Run immediately on start.
+		if err := s.db.DeleteExpiredLeaveRecords(ctx); err != nil {
+			log.Printf("Leave cleanup error: %v\n", err)
+		}
+		for {
+			select {
+			case <-ticker.C:
+				if err := s.db.DeleteExpiredLeaveRecords(ctx); err != nil {
+					log.Printf("Leave cleanup error: %v\n", err)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
 func (s *Server) handleShutdownSignals(parentCtx context.Context, srv *http.Server) {
 	sigint := make(chan os.Signal, 1)
 	signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
@@ -167,6 +191,7 @@ func (s *Server) stopCleanup() {
 
 func (s *Server) Start(ctx context.Context, port string) error {
 	s.setupSessionCleanup(ctx)
+	s.startLeaveCleanup(ctx)
 
 	// Use http.Server with timeouts for production
 	srv := &http.Server{

--- a/internal/database/leave.go
+++ b/internal/database/leave.go
@@ -201,3 +201,12 @@ func (db *DB) DeleteLeaveRecord(ctx context.Context, leaveID string) error {
 
 	return db.queries.DeleteLeaveRecord(ctx, leaveID)
 }
+
+// hoursPerDay is the number of hours in a day.
+const hoursPerDay = 24
+
+// DeleteExpiredLeaveRecords removes leave records whose end date is before today.
+func (db *DB) DeleteExpiredLeaveRecords(ctx context.Context) error {
+	today := time.Now().UTC().Truncate(hoursPerDay * time.Hour)
+	return db.queries.DeleteExpiredLeaveRecords(ctx, today)
+}

--- a/internal/database/leave_test.go
+++ b/internal/database/leave_test.go
@@ -195,15 +195,17 @@ func TestDeleteExpiredLeaveRecords(t *testing.T) {
 	memberID, err := db.AddTeamMember(ctx, "Bob", "bob@example.com")
 	require.NoError(t, err)
 
+	now := time.Now().UTC()
+
 	// Create an expired leave record (ended yesterday).
-	pastStart := time.Now().AddDate(0, 0, -5).Format("2006-01-02")
-	pastEnd := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+	pastStart := now.AddDate(0, 0, -5).Format("2006-01-02")
+	pastEnd := now.AddDate(0, 0, -1).Format("2006-01-02")
 	expiredID, err := db.CreateLeaveRecord(ctx, memberID, pastStart, pastEnd)
 	require.NoError(t, err)
 
 	// Create a current / future leave record.
-	futureStart := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
-	futureEnd := time.Now().AddDate(0, 0, 3).Format("2006-01-02")
+	futureStart := now.AddDate(0, 0, 1).Format("2006-01-02")
+	futureEnd := now.AddDate(0, 0, 3).Format("2006-01-02")
 	futureID, err := db.CreateLeaveRecord(ctx, memberID, futureStart, futureEnd)
 	require.NoError(t, err)
 

--- a/internal/database/leave_test.go
+++ b/internal/database/leave_test.go
@@ -186,3 +186,37 @@ func TestGetLeaveByID_NotFound(t *testing.T) {
 	// Assert
 	require.Error(t, err)
 }
+
+func TestDeleteExpiredLeaveRecords(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	memberID, err := db.AddTeamMember(ctx, "Bob", "bob@example.com")
+	require.NoError(t, err)
+
+	// Create an expired leave record (ended yesterday).
+	pastStart := time.Now().AddDate(0, 0, -5).Format("2006-01-02")
+	pastEnd := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+	expiredID, err := db.CreateLeaveRecord(ctx, memberID, pastStart, pastEnd)
+	require.NoError(t, err)
+
+	// Create a current / future leave record.
+	futureStart := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+	futureEnd := time.Now().AddDate(0, 0, 3).Format("2006-01-02")
+	futureID, err := db.CreateLeaveRecord(ctx, memberID, futureStart, futureEnd)
+	require.NoError(t, err)
+
+	// Act.
+	err = db.DeleteExpiredLeaveRecords(ctx)
+	require.NoError(t, err)
+
+	// Expired record should be gone.
+	_, err = db.GetLeaveByID(ctx, expiredID)
+	require.Error(t, err)
+
+	// Future record should still exist.
+	future, err := db.GetLeaveByID(ctx, futureID)
+	require.NoError(t, err)
+	require.Equal(t, futureID, future.ID)
+}

--- a/internal/database/sqlc/leave_records.sql.go
+++ b/internal/database/sqlc/leave_records.sql.go
@@ -32,6 +32,16 @@ func (q *Queries) CreateLeaveRecord(ctx context.Context, arg CreateLeaveRecordPa
 	)
 }
 
+const deleteExpiredLeaveRecords = `-- name: DeleteExpiredLeaveRecords :exec
+DELETE FROM leave_records
+WHERE end_date < ?
+`
+
+func (q *Queries) DeleteExpiredLeaveRecords(ctx context.Context, endDate time.Time) error {
+	_, err := q.db.ExecContext(ctx, deleteExpiredLeaveRecords, endDate)
+	return err
+}
+
 const deleteLeaveRecord = `-- name: DeleteLeaveRecord :exec
 DELETE FROM leave_records
 WHERE id = ?

--- a/internal/database/sqlc/querier.go
+++ b/internal/database/sqlc/querier.go
@@ -29,6 +29,7 @@ type Querier interface {
 	DeleteAPIToken(ctx context.Context, id string) (sql.Result, error)
 	DeleteAssignmentsByDateRange(ctx context.Context, arg DeleteAssignmentsByDateRangeParams) error
 	DeleteCalendarSubscription(ctx context.Context, token string) error
+	DeleteExpiredLeaveRecords(ctx context.Context, endDate time.Time) error
 	DeleteExpiredSessions(ctx context.Context) error
 	DeleteLeaveRecord(ctx context.Context, id string) error
 	DeleteMemberSubscriptions(ctx context.Context, memberID string) error

--- a/internal/database/sqlc/queries/leave_records.sql
+++ b/internal/database/sqlc/queries/leave_records.sql
@@ -36,3 +36,7 @@ WHERE id = ?;
 -- name: DeleteLeaveRecord :exec
 DELETE FROM leave_records
 WHERE id = ?;
+
+-- name: DeleteExpiredLeaveRecords :exec
+DELETE FROM leave_records
+WHERE end_date < ?;


### PR DESCRIPTION
## Summary

Adds a background cleanup task that automatically removes leave records whose `end_date` is in the past.

## Changes

- **SQL**: Added `DeleteExpiredLeaveRecords` query — deletes rows where `end_date < today`
- **SQLC**: Regenerated `leave_records.sql.go` and `querier.go` with the new method
- **DB layer**: Added `DeleteExpiredLeaveRecords(ctx)` wrapper in `internal/database/leave.go`
- **Server**: Added `leaveCleanupInterval` constant (24h) and `startLeaveCleanup(ctx)` background goroutine, called from `Server.Start()` alongside the existing session cleanup; runs immediately on startup then every 24 hours
- **Tests**: Added `TestDeleteExpiredLeaveRecords` verifying past records are deleted and future records are preserved

## Review checklist

- All tests pass (`go test ./...`)
- Lint clean (`golangci-lint run` — 0 issues)
