### PR TITLE
fix(calendar): use addfromweb for Outlook subscription and set 1h refresh interval

### DIFF
--- a/internal/calendar/ical.go
+++ b/internal/calendar/ical.go
@@ -57,6 +57,8 @@ func NewICalGeneratorWithMetadata(name, description string) *ICalGenerator {
 	cal.SetVersion("2.0")
 	cal.SetCalscale("GREGORIAN")
 	cal.SetMethod(ics.MethodPublish)
+	cal.SetRefreshInterval("PT1H")
+	cal.SetXPublishedTTL("PT1H")
 
 	return &ICalGenerator{calendar: cal}
 }

--- a/internal/calendar/ical_test.go
+++ b/internal/calendar/ical_test.go
@@ -330,6 +330,8 @@ func TestICalGenerator_CalendarProperties(t *testing.T) {
 	assert.Contains(t, icalStr, "X-WR-CALNAME:Support Rota Calendar")
 	// The library uses NAME and DESCRIPTION properties instead of X-WR-CALDESC
 	assert.Contains(t, icalStr, "DESCRIPTION:Automated support rota assignments")
+	assert.Contains(t, icalStr, "REFRESH-INTERVAL;VALUE=DURATION:PT1H")
+	assert.Contains(t, icalStr, "X-PUBLISHED-TTL:PT1H")
 }
 
 func TestICalGenerator_ComplexScenario(t *testing.T) {

--- a/internal/web/calendar_handlers.go
+++ b/internal/web/calendar_handlers.go
@@ -102,14 +102,15 @@ func outlookSubscriptionURL(r *http.Request, path string, calendarName string) t
 	base.RawQuery = ""
 	base.Fragment = ""
 
-	outlookURL, err := url.Parse("https://outlook.office.com/calendar/0/deeplink/compose")
+	// Use the addfromweb endpoint to trigger a calendar subscription rather than
+	// event creation. The deeplink/compose?rru=addsubscription format is no longer
+	// reliable and may open the event composer instead.
+	outlookURL, err := url.Parse("https://outlook.office.com/calendar/0/addfromweb")
 	if err != nil {
 		return ""
 	}
 
 	query := outlookURL.Query()
-	query.Set("path", "/calendar/action/compose")
-	query.Set("rru", "addsubscription")
 	query.Set("url", base.String())
 	query.Set("name", calendarName)
 	outlookURL.RawQuery = query.Encode()

--- a/internal/web/calendar_handlers_test.go
+++ b/internal/web/calendar_handlers_test.go
@@ -40,11 +40,11 @@ func TestOutlookSubscriptionURL_UsesHTTPSAndName(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https", parsed.Scheme)
 	assert.Equal(t, "outlook.office.com", parsed.Host)
-	assert.Equal(t, "/calendar/0/deeplink/compose", parsed.Path)
+	assert.Equal(t, "/calendar/0/addfromweb", parsed.Path)
 
 	query := parsed.Query()
-	assert.Equal(t, "/calendar/action/compose", query.Get("path"))
-	assert.Equal(t, "addsubscription", query.Get("rru"))
 	assert.Equal(t, "Support rota", query.Get("name"))
 	assert.Equal(t, "https://example.com/calendar/test-token/ics", query.Get("url"))
+	assert.Empty(t, query.Get("path"))
+	assert.Empty(t, query.Get("rru"))
 }

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -184,9 +184,9 @@ func TestAllTemplatesWithData(t *testing.T) {
 		"MeetingsCalendarURL":       "https://example.com/calendar/test-token/meetings.ics",
 		"CalendarWebcalURL":         template.URL("webcal://example.com/calendar/test-token/ics"),
 		"MeetingsCalendarWebcalURL": template.URL("webcal://example.com/calendar/test-token/meetings.ics"),
-		"CalendarOutlookURL":        template.URL("https://outlook.office.com/calendar/0/deeplink/compose?path=%2Fcalendar%2Faction%2Fcompose&rru=addsubscription&url=https%3A%2F%2Fexample.com%2Fcalendar%2Ftest-token%2Fics&name=Support+rota"),
+		"CalendarOutlookURL":        template.URL("https://outlook.office.com/calendar/0/addfromweb?url=https%3A%2F%2Fexample.com%2Fcalendar%2Ftest-token%2Fics&name=Support+rota"),
 		"MeetingsCalendarOutlookURL": template.URL(
-			"https://outlook.office.com/calendar/0/deeplink/compose?path=%2Fcalendar%2Faction%2Fcompose&rru=addsubscription&url=https%3A%2F%2Fexample.com%2Fcalendar%2Ftest-token%2Fmeetings.ics&name=Support+meetings",
+			"https://outlook.office.com/calendar/0/addfromweb?url=https%3A%2F%2Fexample.com%2Fcalendar%2Ftest-token%2Fmeetings.ics&name=Support+meetings",
 		),
 		"ShowResult": true,
 		"Members": []map[string]any{
@@ -224,7 +224,7 @@ func TestAllTemplatesWithData(t *testing.T) {
 			assert.Equal(t, 200, w.Code, "Template %s should return 200", tc.template)
 			assert.NotEmpty(t, w.Body.String(), "Template %s should produce output", tc.template)
 			if tc.name == "CalendarShowResult" {
-				assert.Contains(t, w.Body.String(), "addsubscription")
+				assert.Contains(t, w.Body.String(), "addfromweb")
 				assert.NotContains(t, w.Body.String(), "#ZgotmplZ")
 			}
 		})


### PR DESCRIPTION
## Summary

Two calendar subscription improvements:

### Fix Outlook subscription URL

The old `deeplink/compose?rru=addsubscription` endpoint was opening Outlook's event creation dialog instead of the calendar subscription dialog. Changed to the correct `/calendar/0/addfromweb?url=...&name=...` endpoint so clicking the Outlook button now prompts users to subscribe to the calendar feed.

### Set ICS refresh interval to 1 hour

Added `REFRESH-INTERVAL;VALUE=DURATION:PT1H` and `X-PUBLISHED-TTL:PT1H` properties to all generated ICS feeds. This tells calendar clients (Outlook, Google Calendar, Apple Calendar) to refresh the feed every hour, keeping displayed schedules up to date.

## Changes

- `internal/web/calendar_handlers.go` — fix `outlookSubscriptionURL()` to use `addfromweb` endpoint
- `internal/web/calendar_handlers_test.go` — update test to assert new endpoint path
- `internal/calendar/ical.go` — add `SetRefreshInterval("PT1H")` and `SetXPublishedTTL("PT1H")` to `NewICalGeneratorWithMetadata`
- `internal/calendar/ical_test.go` — assert both refresh properties appear in serialized output