### PR TITLE
feat(calendar): add 1-day advance alarm to personal HAT day events

### DIFF
--- a/internal/calendar/ical.go
+++ b/internal/calendar/ical.go
@@ -47,6 +47,7 @@ type ICalGenerator struct {
 
 type SupportCalendarOptions struct {
 	SupportDayLinks []MeetingLink
+	WithAlarm       bool
 }
 
 // NewICalGeneratorWithMetadata creates a new iCalendar generator with custom metadata.
@@ -77,7 +78,7 @@ func (g *ICalGenerator) WithSupportDayLinks(links []MeetingLink) *ICalGenerator 
 	return g
 }
 
-// WithAlarm enables a 1-day advance display notification on each event.
+// WithAlarm enables a 1-day advance display notification on each assignment event.
 func (g *ICalGenerator) WithAlarm() *ICalGenerator {
 	g.withAlarm = true
 	return g
@@ -363,7 +364,10 @@ func (g *ICalGenerator) SerializeBytes() ([]byte, error) {
 
 // GenerateICalFromAssignmentsWithOptions creates a complete iCalendar file from rota assignments.
 func GenerateICalFromAssignmentsWithOptions(assignments []database.RotaAssignment, memberName string, opts SupportCalendarOptions) (string, error) {
-	generator := NewICalGenerator().WithSupportDayLinks(opts.SupportDayLinks).WithAlarm()
+	generator := NewICalGenerator().WithSupportDayLinks(opts.SupportDayLinks)
+	if opts.WithAlarm {
+		generator = generator.WithAlarm()
+	}
 
 	for _, assignment := range assignments {
 		if err := generator.AddAssignment(assignment, memberName); err != nil {

--- a/internal/calendar/ical.go
+++ b/internal/calendar/ical.go
@@ -42,6 +42,7 @@ type ICalGenerator struct {
 	calendar *ics.Calendar
 
 	supportDayLinks []MeetingLink
+	withAlarm       bool
 }
 
 type SupportCalendarOptions struct {
@@ -73,6 +74,12 @@ func NewICalGenerator() *ICalGenerator {
 
 func (g *ICalGenerator) WithSupportDayLinks(links []MeetingLink) *ICalGenerator {
 	g.supportDayLinks = links
+	return g
+}
+
+// WithAlarm enables a 1-day advance display notification on each event.
+func (g *ICalGenerator) WithAlarm() *ICalGenerator {
+	g.withAlarm = true
 	return g
 }
 
@@ -131,6 +138,14 @@ func (g *ICalGenerator) AddAssignment(assignment database.RotaAssignment, member
 
 	// Set last modified timestamp
 	event.SetModifiedAt(time.Now().UTC())
+
+	// Add a 1-day advance reminder for personal calendars.
+	if g.withAlarm {
+		alarm := event.AddAlarm()
+		alarm.SetAction(ics.ActionDisplay)
+		alarm.SetTrigger("-P1D")
+		alarm.SetDescription(summary)
+	}
 
 	return nil
 }
@@ -348,7 +363,7 @@ func (g *ICalGenerator) SerializeBytes() ([]byte, error) {
 
 // GenerateICalFromAssignmentsWithOptions creates a complete iCalendar file from rota assignments.
 func GenerateICalFromAssignmentsWithOptions(assignments []database.RotaAssignment, memberName string, opts SupportCalendarOptions) (string, error) {
-	generator := NewICalGenerator().WithSupportDayLinks(opts.SupportDayLinks)
+	generator := NewICalGenerator().WithSupportDayLinks(opts.SupportDayLinks).WithAlarm()
 
 	for _, assignment := range assignments {
 		if err := generator.AddAssignment(assignment, memberName); err != nil {

--- a/internal/calendar/ical_test.go
+++ b/internal/calendar/ical_test.go
@@ -502,3 +502,44 @@ func TestICalGenerator_SequenceAndModified(t *testing.T) {
 	// Should contain last modified timestamp
 	assert.Contains(t, icalStr, "LAST-MODIFIED:")
 }
+
+func TestICalGenerator_WithAlarm(t *testing.T) {
+	generator := NewICalGenerator().WithAlarm()
+
+	assignment := database.RotaAssignment{
+		ID:       "test-alarm-123",
+		Date:     "2026-01-15",
+		MemberID: "member-1",
+		IsCover:  false,
+	}
+
+	err := generator.AddAssignment(assignment, "John Doe")
+	require.NoError(t, err)
+
+	icalStr, err := generator.Serialize()
+	require.NoError(t, err)
+
+	assert.Contains(t, icalStr, "BEGIN:VALARM")
+	assert.Contains(t, icalStr, "ACTION:DISPLAY")
+	assert.Contains(t, icalStr, "TRIGGER:-P1D")
+	assert.Contains(t, icalStr, "END:VALARM")
+}
+
+func TestICalGenerator_NoAlarmByDefault(t *testing.T) {
+	generator := NewICalGenerator()
+
+	assignment := database.RotaAssignment{
+		ID:       "test-no-alarm-456",
+		Date:     "2026-01-15",
+		MemberID: "member-1",
+		IsCover:  false,
+	}
+
+	err := generator.AddAssignment(assignment, "John Doe")
+	require.NoError(t, err)
+
+	icalStr, err := generator.Serialize()
+	require.NoError(t, err)
+
+	assert.NotContains(t, icalStr, "BEGIN:VALARM")
+}

--- a/internal/web/calendar_handlers.go
+++ b/internal/web/calendar_handlers.go
@@ -215,7 +215,7 @@ func (h *Handler) handleCalendarICS(w http.ResponseWriter, r *http.Request) {
 		h.db,
 		token,
 		defaultCalendarLookaheadDays,
-		calendar.SupportCalendarOptions{SupportDayLinks: supportDayLinks},
+		calendar.SupportCalendarOptions{SupportDayLinks: supportDayLinks, WithAlarm: true},
 	)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)


### PR DESCRIPTION
## Summary

Add a `VALARM` (display action, `-P1D` trigger) to the personal HAT day iCal feed so calendar clients notify the assigned person the day before their HAT day.

## Changes

- Add `withAlarm bool` field and `WithAlarm()` fluent setter to `ICalGenerator`
- Emit `VALARM` sub-component in `AddAssignment` when `withAlarm` is set
- Enable alarm in `GenerateICalFromAssignmentsWithOptions` (personal feed only)
- Team and others calendar feeds are unchanged

## Tests

- `TestICalGenerator_WithAlarm` — verifies `VALARM`, `ACTION:DISPLAY`, `TRIGGER:-P1D` present
- `TestICalGenerator_NoAlarmByDefault` — verifies no `VALARM` on a plain generator (regression guard)

## Notes

Alarm support in subscribed `.ics` feeds varies by client: Apple Calendar and Outlook generally honour them; Google Calendar currently ignores alarms on subscribed feeds.