### PR TITLE
Fix holiday-aware schedule generation and preserve regeneration rotation

### DIFF
--- a/internal/api/auth_setup.go
+++ b/internal/api/auth_setup.go
@@ -19,10 +19,9 @@ func setupAuth(db *database.DB, development bool) (*auth.AuthManager, *auth.Midd
 func setupDevelopmentAuth(db *database.DB) (*auth.AuthManager, *auth.Middleware, *auth.SessionManager, error) {
 	log.Println("Development mode: Using fake OAuth provider")
 
-	//nolint:gosec // Development-only fake OAuth credentials.
 	fakeConfig := auth.ProviderConfig{
 		ClientID:     "dev-client-id",
-		ClientSecret: "dev-client-secret",
+		ClientSecret: "dev-client-secret", // #nosec G101
 		RedirectURL:  "http://localhost:8080/auth/callback?provider=fake",
 		AuthURL:      "/auth/fake/login",
 		TokenURL:     "/auth/fake/token",

--- a/internal/api/auth_setup.go
+++ b/internal/api/auth_setup.go
@@ -19,6 +19,7 @@ func setupAuth(db *database.DB, development bool) (*auth.AuthManager, *auth.Midd
 func setupDevelopmentAuth(db *database.DB) (*auth.AuthManager, *auth.Middleware, *auth.SessionManager, error) {
 	log.Println("Development mode: Using fake OAuth provider")
 
+	//nolint:gosec // Development-only fake OAuth credentials.
 	fakeConfig := auth.ProviderConfig{
 		ClientID:     "dev-client-id",
 		ClientSecret: "dev-client-secret",

--- a/internal/api/handlers_leave.go
+++ b/internal/api/handlers_leave.go
@@ -7,7 +7,6 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/inful/madhatter/internal/auth"
 	"github.com/inful/madhatter/internal/database"
-	"github.com/inful/madhatter/internal/rota"
 )
 
 type ReportLeaveInput struct {
@@ -177,7 +176,7 @@ func (s *Server) handleUpdateLeave(ctx context.Context, input *UpdateLeaveInput)
 	}
 
 	// Update schedule after modification
-	maintenance := rota.NewScheduleMaintenance(s.db)
+	maintenance := s.newScheduleMaintenance()
 	if err := maintenance.HandleLeaveChange(ctx, input.ID); err != nil {
 		return nil, huma.Error500InternalServerError("Failed to update schedule", err)
 	}
@@ -220,7 +219,7 @@ func (s *Server) handleDeleteLeave(ctx context.Context, input *DeleteLeaveInput)
 	}
 
 	// Reconcile schedule - will remove any stale covers automatically
-	maintenance := rota.NewScheduleMaintenance(s.db)
+	maintenance := s.newScheduleMaintenance()
 	if err := maintenance.HandleTeamChange(ctx); err != nil {
 		return nil, huma.Error500InternalServerError("Failed to update schedule", err)
 	}

--- a/internal/api/handlers_team.go
+++ b/internal/api/handlers_team.go
@@ -6,7 +6,6 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/inful/madhatter/internal/auth"
 	"github.com/inful/madhatter/internal/database"
-	"github.com/inful/madhatter/internal/rota"
 )
 
 type AddTeamInput struct {
@@ -155,7 +154,7 @@ func (s *Server) handleDeleteTeam(ctx context.Context, input *DeleteTeamInput) (
 	}
 
 	// Update schedule after deletion
-	maintenance := rota.NewScheduleMaintenance(s.db)
+	maintenance := s.newScheduleMaintenance()
 	if err := maintenance.HandleTeamChange(ctx); err != nil {
 		return nil, huma.Error500InternalServerError("Failed to update schedule", err)
 	}

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -362,7 +362,7 @@ func TestCalendarEndpoints(t *testing.T) {
 		router := chi.NewRouter()
 		router.Get("/api/v1/calendar/{token}/ics", server.handleCalendarICS)
 
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/calendar/"+token+"/ics", nil)
+		req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/calendar/"+token+"/ics", nil)
 		w := httptest.NewRecorder()
 
 		router.ServeHTTP(w, req)

--- a/internal/api/security_http_integration_test.go
+++ b/internal/api/security_http_integration_test.go
@@ -29,7 +29,7 @@ func doJSONRequest(t *testing.T, server *Server, method, path string, body any, 
 		bodyReader = bytes.NewReader(nil)
 	}
 
-	req := httptest.NewRequest(method, path, bodyReader)
+	req := httptest.NewRequestWithContext(context.Background(), method, path, bodyReader)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -138,6 +138,15 @@ func (s *Server) setupSessionCleanup(ctx context.Context) {
 	}
 }
 
+func (s *Server) newScheduleMaintenance() *rota.ScheduleMaintenance {
+	maintenance := rota.NewScheduleMaintenance(s.db)
+	if s.holidayService != nil {
+		maintenance.SetHolidayChecker(s.holidayService.ShouldSkipDate)
+	}
+
+	return maintenance
+}
+
 // startLeaveCleanup starts a background goroutine that deletes expired leave records daily.
 func (s *Server) startLeaveCleanup() {
 	log.Println("Starting leave record cleanup task...")

--- a/internal/auth/fake_provider_test.go
+++ b/internal/auth/fake_provider_test.go
@@ -16,10 +16,9 @@ import (
 
 // TestFakeProvider_Name tests that the fake provider returns the correct name.
 func TestFakeProvider_Name(t *testing.T) {
-	//nolint:gosec // Test-only OAuth configuration values.
 	config := ProviderConfig{
 		ClientID:     "test-client",
-		ClientSecret: "test-secret",
+		ClientSecret: "test-secret", // #nosec G101 -- test-only fake OAuth secret.
 		RedirectURL:  "http://localhost:8080/auth/callback",
 		AuthURL:      "/auth/fake/login",
 		TokenURL:     "/auth/fake/token",
@@ -33,10 +32,9 @@ func TestFakeProvider_Name(t *testing.T) {
 
 // TestFakeProvider_GetAuthURL tests that the fake provider returns a valid auth URL.
 func TestFakeProvider_GetAuthURL(t *testing.T) {
-	//nolint:gosec // Test-only OAuth configuration values.
 	config := ProviderConfig{
 		ClientID:     "test-client",
-		ClientSecret: "test-secret",
+		ClientSecret: "test-secret", // #nosec G101 -- test-only fake OAuth secret.
 		RedirectURL:  "http://localhost:8080/auth/callback",
 		AuthURL:      "/auth/fake/login",
 		TokenURL:     "/auth/fake/token",
@@ -56,10 +54,9 @@ func TestFakeProvider_GetAuthURL(t *testing.T) {
 
 // TestFakeProvider_ExchangeCode tests that the fake provider returns fake tokens.
 func TestFakeProvider_ExchangeCode(t *testing.T) {
-	//nolint:gosec // Test-only OAuth configuration values.
 	config := ProviderConfig{
 		ClientID:     "test-client",
-		ClientSecret: "test-secret",
+		ClientSecret: "test-secret", // #nosec G101 -- test-only fake OAuth secret.
 		RedirectURL:  "http://localhost:8080/auth/callback",
 		AuthURL:      "/auth/fake/login",
 		TokenURL:     "/auth/fake/token",
@@ -80,10 +77,9 @@ func TestFakeProvider_ExchangeCode(t *testing.T) {
 
 // TestFakeProvider_GetUserInfo tests that the fake provider returns fake user info.
 func TestFakeProvider_GetUserInfo(t *testing.T) {
-	//nolint:gosec // Test-only OAuth configuration values.
 	config := ProviderConfig{
 		ClientID:     "test-client",
-		ClientSecret: "test-secret",
+		ClientSecret: "test-secret", // #nosec G101 -- test-only fake OAuth secret.
 		RedirectURL:  "http://localhost:8080/auth/callback",
 		AuthURL:      "/auth/fake/login",
 		TokenURL:     "/auth/fake/token",
@@ -109,10 +105,9 @@ func TestFakeProvider_GetUserInfo(t *testing.T) {
 
 // TestFakeProvider_GetOAuthConfig tests that the fake provider returns valid OAuth config.
 func TestFakeProvider_GetOAuthConfig(t *testing.T) {
-	//nolint:gosec // Test-only OAuth configuration values.
 	config := ProviderConfig{
 		ClientID:     "test-client",
-		ClientSecret: "test-secret",
+		ClientSecret: "test-secret", // #nosec G101 -- test-only fake OAuth secret.
 		RedirectURL:  "http://localhost:8080/auth/callback",
 		AuthURL:      "/auth/fake/login",
 		TokenURL:     "/auth/fake/token",
@@ -219,10 +214,9 @@ func TestGetDevelopmentLoginHTML(t *testing.T) {
 // TestFakeProvider_Integration tests the complete fake OAuth flow.
 func TestFakeProvider_Integration(t *testing.T) {
 	// Setup
-	//nolint:gosec // Test-only OAuth configuration values.
 	config := ProviderConfig{
 		ClientID:     "dev-client",
-		ClientSecret: "dev-secret",
+		ClientSecret: "dev-secret", // #nosec G101 -- test-only fake OAuth secret.
 		RedirectURL:  "http://localhost:8080/auth/callback",
 		AuthURL:      "/auth/fake/login",
 		TokenURL:     "/auth/fake/token",

--- a/internal/auth/fake_provider_test.go
+++ b/internal/auth/fake_provider_test.go
@@ -16,6 +16,7 @@ import (
 
 // TestFakeProvider_Name tests that the fake provider returns the correct name.
 func TestFakeProvider_Name(t *testing.T) {
+	//nolint:gosec // Test-only OAuth configuration values.
 	config := ProviderConfig{
 		ClientID:     "test-client",
 		ClientSecret: "test-secret",
@@ -32,6 +33,7 @@ func TestFakeProvider_Name(t *testing.T) {
 
 // TestFakeProvider_GetAuthURL tests that the fake provider returns a valid auth URL.
 func TestFakeProvider_GetAuthURL(t *testing.T) {
+	//nolint:gosec // Test-only OAuth configuration values.
 	config := ProviderConfig{
 		ClientID:     "test-client",
 		ClientSecret: "test-secret",
@@ -54,6 +56,7 @@ func TestFakeProvider_GetAuthURL(t *testing.T) {
 
 // TestFakeProvider_ExchangeCode tests that the fake provider returns fake tokens.
 func TestFakeProvider_ExchangeCode(t *testing.T) {
+	//nolint:gosec // Test-only OAuth configuration values.
 	config := ProviderConfig{
 		ClientID:     "test-client",
 		ClientSecret: "test-secret",
@@ -77,6 +80,7 @@ func TestFakeProvider_ExchangeCode(t *testing.T) {
 
 // TestFakeProvider_GetUserInfo tests that the fake provider returns fake user info.
 func TestFakeProvider_GetUserInfo(t *testing.T) {
+	//nolint:gosec // Test-only OAuth configuration values.
 	config := ProviderConfig{
 		ClientID:     "test-client",
 		ClientSecret: "test-secret",
@@ -105,6 +109,7 @@ func TestFakeProvider_GetUserInfo(t *testing.T) {
 
 // TestFakeProvider_GetOAuthConfig tests that the fake provider returns valid OAuth config.
 func TestFakeProvider_GetOAuthConfig(t *testing.T) {
+	//nolint:gosec // Test-only OAuth configuration values.
 	config := ProviderConfig{
 		ClientID:     "test-client",
 		ClientSecret: "test-secret",
@@ -131,7 +136,7 @@ func TestFakeProvider_GetOAuthConfig(t *testing.T) {
 func TestFakeCallbackHandler_HandleLogin(t *testing.T) {
 	handler := NewFakeCallbackHandler()
 
-	req := httptest.NewRequest(http.MethodGet, "/auth/fake/login?state=test-state", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/auth/fake/login?state=test-state", nil)
 	w := httptest.NewRecorder()
 
 	handler.HandleLogin(w, req)
@@ -165,11 +170,11 @@ func TestFakeCallbackHandler_HandleLogin_UniqueStates(t *testing.T) {
 	handler := NewFakeCallbackHandler()
 
 	// Make two requests
-	req1 := httptest.NewRequest(http.MethodGet, "/auth/fake/login", nil)
+	req1 := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/auth/fake/login", nil)
 	w1 := httptest.NewRecorder()
 	handler.HandleLogin(w1, req1)
 
-	req2 := httptest.NewRequest(http.MethodGet, "/auth/fake/login", nil)
+	req2 := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/auth/fake/login", nil)
 	w2 := httptest.NewRecorder()
 	handler.HandleLogin(w2, req2)
 
@@ -214,6 +219,7 @@ func TestGetDevelopmentLoginHTML(t *testing.T) {
 // TestFakeProvider_Integration tests the complete fake OAuth flow.
 func TestFakeProvider_Integration(t *testing.T) {
 	// Setup
+	//nolint:gosec // Test-only OAuth configuration values.
 	config := ProviderConfig{
 		ClientID:     "dev-client",
 		ClientSecret: "dev-secret",
@@ -233,7 +239,7 @@ func TestFakeProvider_Integration(t *testing.T) {
 	assert.Contains(t, authURL, "/auth/fake/login")
 
 	// Step 2: Simulate login redirect
-	req := httptest.NewRequest(http.MethodGet, authURL, nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, authURL, nil)
 	w := httptest.NewRecorder()
 	handler.HandleLogin(w, req)
 

--- a/internal/auth/forgejo.go
+++ b/internal/auth/forgejo.go
@@ -66,11 +66,13 @@ func (p *ForgejoProvider) ExchangeCode(ctx context.Context, code string) (*oauth
 func (p *ForgejoProvider) GetUserInfo(ctx context.Context, token *oauth2.Token) (*UserInfo, error) {
 	client := p.oauth.Client(ctx, token)
 
+	//nolint:gosec // UserInfoURL is controlled by validated provider configuration.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.config.UserInfoURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrUserInfo, err)
 	}
 
+	//nolint:gosec // Request target is controlled by validated provider configuration.
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrUserInfo, err)

--- a/internal/auth/forgejo.go
+++ b/internal/auth/forgejo.go
@@ -66,14 +66,12 @@ func (p *ForgejoProvider) ExchangeCode(ctx context.Context, code string) (*oauth
 func (p *ForgejoProvider) GetUserInfo(ctx context.Context, token *oauth2.Token) (*UserInfo, error) {
 	client := p.oauth.Client(ctx, token)
 
-	//nolint:gosec // UserInfoURL is controlled by validated provider configuration.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.config.UserInfoURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.config.UserInfoURL, nil) // #nosec G704 -- URL comes from validated provider configuration.
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrUserInfo, err)
 	}
 
-	//nolint:gosec // Request target is controlled by validated provider configuration.
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- Request target comes from validated provider configuration.
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrUserInfo, err)
 	}

--- a/internal/auth/gitlab.go
+++ b/internal/auth/gitlab.go
@@ -66,14 +66,12 @@ func (p *GitLabProvider) ExchangeCode(ctx context.Context, code string) (*oauth2
 func (p *GitLabProvider) GetUserInfo(ctx context.Context, token *oauth2.Token) (*UserInfo, error) {
 	client := p.oauth.Client(ctx, token)
 
-	//nolint:gosec // UserInfoURL is controlled by validated provider configuration.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.config.UserInfoURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.config.UserInfoURL, nil) // #nosec G704 -- URL comes from validated provider configuration.
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrUserInfo, err)
 	}
 
-	//nolint:gosec // Request target is controlled by validated provider configuration.
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- Request target comes from validated provider configuration.
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrUserInfo, err)
 	}
@@ -143,14 +141,12 @@ func (p *GitLabProvider) checkGroupMembership(ctx context.Context, client *http.
 	// This returns all groups the user is a member of
 	groupsURL := fmt.Sprintf("%s/groups?min_access_level=10", baseURL)
 
-	//nolint:gosec // groupsURL is derived from validated provider configuration.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, groupsURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, groupsURL, nil) // #nosec G704 -- URL is derived from validated provider configuration.
 	if err != nil {
 		return false, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	//nolint:gosec // Request target is derived from validated provider configuration.
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- Request target is derived from validated provider configuration.
 	if err != nil {
 		return false, fmt.Errorf("failed to fetch groups: %w", err)
 	}

--- a/internal/auth/gitlab.go
+++ b/internal/auth/gitlab.go
@@ -66,11 +66,13 @@ func (p *GitLabProvider) ExchangeCode(ctx context.Context, code string) (*oauth2
 func (p *GitLabProvider) GetUserInfo(ctx context.Context, token *oauth2.Token) (*UserInfo, error) {
 	client := p.oauth.Client(ctx, token)
 
+	//nolint:gosec // UserInfoURL is controlled by validated provider configuration.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.config.UserInfoURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrUserInfo, err)
 	}
 
+	//nolint:gosec // Request target is controlled by validated provider configuration.
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrUserInfo, err)
@@ -141,11 +143,13 @@ func (p *GitLabProvider) checkGroupMembership(ctx context.Context, client *http.
 	// This returns all groups the user is a member of
 	groupsURL := fmt.Sprintf("%s/groups?min_access_level=10", baseURL)
 
+	//nolint:gosec // groupsURL is derived from validated provider configuration.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, groupsURL, nil)
 	if err != nil {
 		return false, fmt.Errorf("failed to create request: %w", err)
 	}
 
+	//nolint:gosec // Request target is derived from validated provider configuration.
 	resp, err := client.Do(req)
 	if err != nil {
 		return false, fmt.Errorf("failed to fetch groups: %w", err)

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -258,10 +258,10 @@ func (am *AuthManager) HandleLoginView(w http.ResponseWriter, r *http.Request) {
 `)
 	for _, provider := range providers {
 		displayName := capitalizeProviderName(provider)
-		html.WriteString(fmt.Sprintf(`        <li class="provider-item">
+		fmt.Fprintf(&html, `        <li class="provider-item">
 	           <a href="/auth/login/%s" class="provider-btn">Login with %s</a>
 	       </li>
-`, provider, displayName))
+`, provider, displayName)
 	}
 	html.WriteString(`    </ul>
 </body>

--- a/internal/auth/handlers_test.go
+++ b/internal/auth/handlers_test.go
@@ -109,7 +109,7 @@ func TestAuthManager_HandleLogin(t *testing.T) {
 	authManager.RegisterProvider(fakeProvider)
 
 	// Create request with correct URL pattern and chi route context
-	req := httptest.NewRequest(http.MethodGet, "/auth/login/fake", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/auth/login/fake", nil)
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("provider", "fake")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
@@ -152,7 +152,7 @@ func TestAuthManager_HandleLogin_MissingProvider(t *testing.T) {
 	authManager := NewAuthManager(providerFactory, userService, sessionManager)
 
 	// Create request without provider
-	req := httptest.NewRequest(http.MethodGet, "/auth/login/", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/auth/login/", nil)
 	w := httptest.NewRecorder()
 
 	// Test
@@ -178,7 +178,7 @@ func TestAuthManager_HandleLogin_InvalidProvider(t *testing.T) {
 	authManager := NewAuthManager(providerFactory, userService, sessionManager)
 
 	// Create request with invalid provider
-	req := httptest.NewRequest(http.MethodGet, "/auth/login/invalid", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/auth/login/invalid", nil)
 	w := httptest.NewRecorder()
 
 	// Test
@@ -213,7 +213,7 @@ func TestAuthManager_HandleCallback(t *testing.T) {
 	state := "test-state"
 
 	// Create callback request
-	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test-code&state=test-state&provider=fake", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/auth/callback?code=test-code&state=test-state&provider=fake", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "oauth_state",
 		Value: state,
@@ -264,7 +264,7 @@ func TestAuthManager_HandleCallback_MissingState(t *testing.T) {
 	authManager := NewAuthManager(providerFactory, userService, sessionManager)
 
 	// Create request without state cookie
-	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/auth/callback?code=test", nil)
 	w := httptest.NewRecorder()
 
 	// Test
@@ -290,7 +290,7 @@ func TestAuthManager_HandleCallback_StateMismatch(t *testing.T) {
 	authManager := NewAuthManager(providerFactory, userService, sessionManager)
 
 	// Create request with mismatched state
-	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test&state=wrong", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/auth/callback?code=test&state=wrong", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "oauth_state",
 		Value: "correct-state",
@@ -320,7 +320,7 @@ func TestAuthManager_HandleCallback_MissingProvider(t *testing.T) {
 	authManager := NewAuthManager(providerFactory, userService, sessionManager)
 
 	// Create request without provider
-	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test&state=test", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/auth/callback?code=test&state=test", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "oauth_state",
 		Value: "test",
@@ -356,7 +356,7 @@ func TestAuthManager_HandleCallback_MissingCode(t *testing.T) {
 	authManager.RegisterProvider(fakeProvider)
 
 	// Create request without code
-	req := httptest.NewRequest(http.MethodGet, "/auth/callback?state=test&provider=fake", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/auth/callback?state=test&provider=fake", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "oauth_state",
 		Value: "test",
@@ -400,7 +400,7 @@ func TestAuthManager_HandleLogout(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create logout request
-	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/auth/logout", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "session_token",
 		Value: sessionToken,
@@ -445,7 +445,7 @@ func TestAuthManager_HandleLoginView(t *testing.T) {
 	authManager := NewAuthManager(providerFactory, userService, sessionManager)
 
 	// Create request
-	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/login", nil)
 	w := httptest.NewRecorder()
 
 	// Test
@@ -487,7 +487,7 @@ func TestAuthManager_HandleLoginView_AlreadyLoggedIn(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create request with session
-	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/login", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "session_token",
 		Value: sessionToken,
@@ -530,7 +530,7 @@ func TestAuthManager_HandleGenerateAPIToken(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create request
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tokens/generate?name=my-token", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/tokens/generate?name=my-token", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "session_token",
 		Value: sessionToken,
@@ -571,7 +571,7 @@ func TestAuthManager_HandleGenerateAPIToken_Unauthenticated(t *testing.T) {
 	authManager := NewAuthManager(providerFactory, userService, sessionManager)
 
 	// Create request without auth
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tokens/generate?name=my-token", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/tokens/generate?name=my-token", nil)
 	w := httptest.NewRecorder()
 
 	// Test
@@ -629,7 +629,7 @@ func TestAuthManager_HandleListAPITokens(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create request
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/tokens", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/tokens", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "session_token",
 		Value: sessionToken,
@@ -668,7 +668,7 @@ func TestAuthManager_HandleListAPITokens_Unauthenticated(t *testing.T) {
 	authManager := NewAuthManager(providerFactory, userService, sessionManager)
 
 	// Create request without auth
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/tokens", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/tokens", nil)
 	w := httptest.NewRecorder()
 
 	// Test
@@ -718,7 +718,7 @@ func TestAuthManager_HandleRevokeAPIToken(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create request
-	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tokens/"+tokenID, nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/v1/tokens/"+tokenID, nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "session_token",
 		Value: sessionToken,
@@ -795,7 +795,7 @@ func TestAuthManager_HandleRevokeAPIToken_Unauthorized(t *testing.T) {
 	require.NoError(t, err)
 
 	// User 2 tries to revoke User 1's token
-	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tokens/"+tokenID, nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/v1/tokens/"+tokenID, nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "session_token",
 		Value: sessionToken,
@@ -856,7 +856,7 @@ func TestAuthManager_HandleCleanupExpiredTokens(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create request
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tokens/cleanup", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/tokens/cleanup", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "session_token",
 		Value: sessionToken,
@@ -899,7 +899,7 @@ func TestAuthManager_HandleCleanupExpiredTokens_NotAdmin(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create request
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tokens/cleanup", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/tokens/cleanup", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "session_token",
 		Value: sessionToken,
@@ -929,7 +929,7 @@ func TestAuthManager_HandleCleanupExpiredTokens_Unauthenticated(t *testing.T) {
 	authManager := NewAuthManager(providerFactory, userService, sessionManager)
 
 	// Create request without auth
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tokens/cleanup", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/tokens/cleanup", nil)
 	w := httptest.NewRecorder()
 
 	// Test
@@ -1124,7 +1124,7 @@ func TestAuthManager_HandleRevokeAPIToken_MissingID(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create request without ID
-	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tokens/", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/v1/tokens/", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "session_token",
 		Value: sessionToken,
@@ -1168,7 +1168,7 @@ func TestAuthManager_HandleRevokeAPIToken_NotFound(t *testing.T) {
 
 	// Create request with non-existent token ID
 	nonExistentID := uuid.New().String()
-	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tokens/"+nonExistentID, nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/v1/tokens/"+nonExistentID, nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "session_token",
 		Value: sessionToken,
@@ -1216,7 +1216,7 @@ func TestAuthManager_HandleGenerateAPIToken_WithExpiry(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create request with expiry
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tokens/generate?name=expiring-token&expiry_days=30", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/tokens/generate?name=expiring-token&expiry_days=30", nil)
 	req.AddCookie(&http.Cookie{
 		Name:  "session_token",
 		Value: sessionToken,

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -27,6 +27,7 @@ func getMigrationsPath() (string, error) {
 		if err != nil {
 			return "", err
 		}
+		//nolint:gosec // MIGRATIONS_PATH is an operator-provided local filesystem path.
 		if _, err := os.Stat(abs); err != nil {
 			return "", fmt.Errorf("MIGRATIONS_PATH does not exist: %w", err)
 		}

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -27,8 +27,7 @@ func getMigrationsPath() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		//nolint:gosec // MIGRATIONS_PATH is an operator-provided local filesystem path.
-		if _, err := os.Stat(abs); err != nil {
+		if _, err := os.Stat(abs); err != nil { // #nosec G703 -- MIGRATIONS_PATH is an operator-provided local filesystem path.
 			return "", fmt.Errorf("MIGRATIONS_PATH does not exist: %w", err)
 		}
 		return abs, nil

--- a/internal/rota/maintenance.go
+++ b/internal/rota/maintenance.go
@@ -163,26 +163,47 @@ func (sm *ScheduleMaintenance) getDatesWithAssignments(ctx context.Context, star
 }
 
 // getStartingMemberIndex determines where to start in the rotation.
+// It walks backwards from startDate (up to lookbackDays calendar days) looking
+// for the most recent *non-cover* assignment on a business day so that the
+// rotation anchor is always deterministic, unaffected by weekend boundaries or
+// the presence of cover assignments on the preceding day.
 func (sm *ScheduleMaintenance) getStartingMemberIndex(ctx context.Context, startDate time.Time, members []database.TeamMember) (int, error) {
-	// Find the last assigned member BEFORE the start date to continue the rotation
-	dayBeforeStart := startDate.AddDate(0, 0, -1)
-	assignmentsBefore, err := sm.db.GetAssignmentsByDateRange(
-		ctx,
-		dayBeforeStart.Format("2006-01-02"),
-		dayBeforeStart.Format("2006-01-02"),
-	)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get assignments before range: %w", err)
+	const lookbackDays = 30
+
+	for i := 1; i <= lookbackDays; i++ {
+		day := startDate.AddDate(0, 0, -i)
+
+		// Skip weekends - they never have original assignments.
+		if day.Weekday() == time.Saturday || day.Weekday() == time.Sunday {
+			continue
+		}
+
+		// Skip holidays if a checker is configured.
+		if sm.engine.holidayChecker != nil && sm.engine.holidayChecker(day) {
+			continue
+		}
+
+		assignments, err := sm.db.GetAssignmentsByDateRange(
+			ctx,
+			day.Format("2006-01-02"),
+			day.Format("2006-01-02"),
+		)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get assignments before range: %w", err)
+		}
+
+		// Find a non-cover original assignment - this is the R1 rotation anchor.
+		for _, a := range assignments {
+			if !a.IsCover {
+				memberIndex := sm.findMemberIndex(members, a.MemberID)
+				if memberIndex != -1 {
+					return (memberIndex + 1) % len(members), nil
+				}
+			}
+		}
 	}
 
-	lastAssignedMemberID := sm.findLastAssignedMember(assignmentsBefore, members)
-	memberIndex := sm.findMemberIndex(members, lastAssignedMemberID)
-
-	// If we found a previous assignment, start from the next member
-	// Otherwise start from the beginning
-	if memberIndex != -1 {
-		return (memberIndex + 1) % len(members), nil
-	}
+	// No prior original assignment found; start the rotation from the beginning.
 	return 0, nil
 }
 
@@ -203,7 +224,6 @@ func (sm *ScheduleMaintenance) generateAssignmentsForMissingDates(
 			continue
 		}
 
-		// The engine's processDate will handle holiday checking internally
 		if err := sm.engine.processDate(ctx, currentDate, members, &memberIndex); err != nil {
 			return createdAny, fmt.Errorf("failed to create assignment for %s: %w",
 				currentDate.Format("2006-01-02"), err)
@@ -220,18 +240,22 @@ func (sm *ScheduleMaintenance) generateAssignmentsForMissingDates(
 func (sm *ScheduleMaintenance) shouldSkipDate(date time.Time, datesWithAssignments map[string]bool) bool {
 	dateStr := date.Format("2006-01-02")
 
-	// Skip if this date already has assignments
+	// Skip if this date already has assignments.
 	if datesWithAssignments[dateStr] {
 		return true
 	}
 
-	// Skip weekends
+	// Skip weekends.
 	if date.Weekday() == time.Saturday || date.Weekday() == time.Sunday {
 		return true
 	}
 
-	// Skip holidays - this will be checked by the engine's holiday checker
-	// The engine will handle holiday checking when processing dates
+	// Skip holidays so that processDate is never called on them and createdAny
+	// is only set when an assignment is actually written.
+	if sm.engine.holidayChecker != nil && sm.engine.holidayChecker(date) {
+		return true
+	}
+
 	return false
 }
 
@@ -269,9 +293,9 @@ func (sm *ScheduleMaintenance) RegenerateSchedule(ctx context.Context, start, en
 	}
 
 	for currentDate := start; !currentDate.After(end); currentDate = currentDate.AddDate(0, 0, 1) {
-		if processErr := sm.engine.processDate(ctx, currentDate, members, &memberIndex); processErr != nil {
+		if err = sm.engine.processDate(ctx, currentDate, members, &memberIndex); err != nil {
 			return 0, fmt.Errorf("failed to regenerate assignment for %s: %w",
-				currentDate.Format("2006-01-02"), processErr)
+				currentDate.Format("2006-01-02"), err)
 		}
 	}
 
@@ -387,27 +411,6 @@ func (sm *ScheduleMaintenance) findOriginalMemberID(assignments []database.RotaA
 		}
 	}
 	return ""
-}
-
-// findLastAssignedMember finds the last member who was assigned in the existing schedule.
-// Returns the ID of the last assigned member, or empty string if no assignments exist.
-func (sm *ScheduleMaintenance) findLastAssignedMember(assignments []database.RotaAssignment, _ []database.TeamMember) string {
-	if len(assignments) == 0 {
-		return ""
-	}
-
-	// Find the latest assignment date
-	latestDate := ""
-	latestAssignment := database.RotaAssignment{}
-	for _, a := range assignments {
-		if a.Date > latestDate {
-			latestDate = a.Date
-			latestAssignment = a
-		}
-	}
-
-	// Return the member ID from the latest assignment
-	return latestAssignment.MemberID
 }
 
 // findMemberIndex finds the index of a member in the members slice.

--- a/internal/rota/maintenance.go
+++ b/internal/rota/maintenance.go
@@ -269,9 +269,9 @@ func (sm *ScheduleMaintenance) RegenerateSchedule(ctx context.Context, start, en
 	}
 
 	for currentDate := start; !currentDate.After(end); currentDate = currentDate.AddDate(0, 0, 1) {
-		if err := sm.engine.processDate(ctx, currentDate, members, &memberIndex); err != nil {
+		if processErr := sm.engine.processDate(ctx, currentDate, members, &memberIndex); processErr != nil {
 			return 0, fmt.Errorf("failed to regenerate assignment for %s: %w",
-				currentDate.Format("2006-01-02"), err)
+				currentDate.Format("2006-01-02"), processErr)
 		}
 	}
 

--- a/internal/rota/maintenance.go
+++ b/internal/rota/maintenance.go
@@ -25,6 +25,11 @@ func NewScheduleMaintenance(db *database.DB) *ScheduleMaintenance {
 	}
 }
 
+// SetHolidayChecker configures holiday-aware skipping for maintenance operations.
+func (sm *ScheduleMaintenance) SetHolidayChecker(checker HolidayChecker) {
+	sm.engine.SetHolidayChecker(checker)
+}
+
 // EnsureSchedule guarantees that a schedule exists for the next 14 days from today.
 // It scans the entire 14-day window and fills any gaps, not just at the end.
 // This handles cases where assignments were deleted (e.g., team member removed).
@@ -242,16 +247,32 @@ func (sm *ScheduleMaintenance) HandleTeamChange(ctx context.Context) error {
 // RegenerateSchedule creates a fresh schedule from scratch, replacing all existing assignments
 // in the specified date range. This is useful for initial team setup or schedule resets.
 func (sm *ScheduleMaintenance) RegenerateSchedule(ctx context.Context, start, end time.Time) (int, error) {
+	// Get active team members before rebuilding the range.
+	members, err := sm.db.GetActiveTeamMembers(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get active team members: %w", err)
+	}
+
+	if len(members) == 0 {
+		return 0, errors.New("no active team members")
+	}
+
+	memberIndex, err := sm.getStartingMemberIndex(ctx, start, members)
+	if err != nil {
+		return 0, err
+	}
+
 	// Delete existing assignments in the date range
-	err := sm.db.DeleteAssignmentsInRange(ctx, start.Format("2006-01-02"), end.Format("2006-01-02"))
+	err = sm.db.DeleteAssignmentsInRange(ctx, start.Format("2006-01-02"), end.Format("2006-01-02"))
 	if err != nil {
 		return 0, fmt.Errorf("failed to delete existing assignments: %w", err)
 	}
 
-	// Use the engine's GenerateSchedule which handles all the logic correctly
-	err = sm.engine.GenerateSchedule(ctx, start, end)
-	if err != nil {
-		return 0, err
+	for currentDate := start; !currentDate.After(end); currentDate = currentDate.AddDate(0, 0, 1) {
+		if err := sm.engine.processDate(ctx, currentDate, members, &memberIndex); err != nil {
+			return 0, fmt.Errorf("failed to regenerate assignment for %s: %w",
+				currentDate.Format("2006-01-02"), err)
+		}
 	}
 
 	// Count how many assignments were created

--- a/internal/rota/maintenance_test.go
+++ b/internal/rota/maintenance_test.go
@@ -179,6 +179,45 @@ func TestScheduleMaintenance_GenerateMissingDays(t *testing.T) {
 	})
 }
 
+func TestScheduleMaintenance_GenerateMissingDays_SkipsHolidays(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	_, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+	_, err = db.AddTeamMember(ctx, "Bob", "bob@example.com")
+	require.NoError(t, err)
+
+	maintenance := NewScheduleMaintenance(db)
+	holiday := time.Date(2026, time.January, 6, 0, 0, 0, 0, time.UTC)
+	maintenance.SetHolidayChecker(func(date time.Time) bool {
+		return date.Equal(holiday)
+	})
+
+	startDate := time.Date(2026, time.January, 5, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2026, time.January, 7, 0, 0, 0, 0, time.UTC)
+
+	created, err := maintenance.GenerateMissingDays(ctx, startDate, endDate)
+	require.NoError(t, err)
+	assert.True(t, created)
+
+	assignments, err := db.GetAssignmentsByDate(ctx, holiday.Format("2006-01-02"))
+	require.NoError(t, err)
+	assert.Empty(t, assignments, "holiday should not receive assignments")
+
+	previousDayAssignments, err := db.GetAssignmentsByDate(ctx, startDate.Format("2006-01-02"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, previousDayAssignments, "non-holiday business day should receive assignments")
+
+	nextDayAssignments, err := db.GetAssignmentsByDate(ctx, endDate.Format("2006-01-02"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, nextDayAssignments, "business day after holiday should receive assignments")
+	assert.NotEqual(t, previousDayAssignments[0].MemberID, nextDayAssignments[0].MemberID,
+		"holiday should not consume a rotation turn")
+}
+
 func TestScheduleMaintenance_HandleTeamChange(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()

--- a/internal/rota/maintenance_test.go
+++ b/internal/rota/maintenance_test.go
@@ -580,3 +580,74 @@ func TestScheduleMaintenance_HandleTeamChange_DeleteMemberReschedulesRota(t *tes
 	assert.Empty(t, start, "Schedule should be complete after team member deletion")
 	assert.Empty(t, end, "Schedule should be complete after team member deletion")
 }
+
+// TestGenerateMissingDays_HolidayOnlyRange verifies that GenerateMissingDays returns
+// created=false when every date in the range is either a weekend or a holiday,
+// i.e. no assignment is actually written.
+func TestGenerateMissingDays_HolidayOnlyRange(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	_, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+	_, err = db.AddTeamMember(ctx, "Bob", "bob@example.com")
+	require.NoError(t, err)
+
+	// 2026-01-06 is a Tuesday; make it a holiday.
+	holiday := time.Date(2026, time.January, 6, 0, 0, 0, 0, time.UTC)
+	maintenance := NewScheduleMaintenance(db)
+	maintenance.SetHolidayChecker(func(date time.Time) bool {
+		return date.Equal(holiday)
+	})
+
+	// Range contains only the holiday - no real business day.
+	created, err := maintenance.GenerateMissingDays(ctx, holiday, holiday)
+	require.NoError(t, err)
+	assert.False(t, created, "no assignment should be created when the range is all holidays")
+}
+
+// TestGetStartingMemberIndex_SkipsWeekendBoundary verifies that when the schedule
+// starts on a Monday the rotation anchor is seeded from the most recent Friday
+// assignment (not from Sunday which has no assignment).
+func TestGetStartingMemberIndex_SkipsWeekendBoundary(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	_, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+	_, err = db.AddTeamMember(ctx, "Bob", "bob@example.com")
+	require.NoError(t, err)
+
+	maintenance := NewScheduleMaintenance(db)
+
+	// Create an assignment on Friday 2026-01-09.
+	friday := time.Date(2026, time.January, 9, 0, 0, 0, 0, time.UTC)
+	_, err = db.CreateRotaAssignment(ctx, friday.Format("2006-01-02"), func() string {
+		members, _ := db.GetActiveTeamMembers(ctx)
+		return members[0].ID // Alice
+	}(), false, nil)
+	require.NoError(t, err)
+
+	// Generate assignments starting from Monday 2026-01-12.
+	// The rotation should continue from Alice, so Monday gets Bob.
+	monday := time.Date(2026, time.January, 12, 0, 0, 0, 0, time.UTC)
+	created, err := maintenance.GenerateMissingDays(ctx, monday, monday)
+	require.NoError(t, err)
+	assert.True(t, created, "assignment should be created for Monday")
+
+	mondayAssignments, err := db.GetAssignmentsByDate(ctx, monday.Format("2006-01-02"))
+	require.NoError(t, err)
+	require.NotEmpty(t, mondayAssignments)
+
+	members, err := db.GetActiveTeamMembers(ctx)
+	require.NoError(t, err)
+	require.Len(t, members, 2)
+
+	// Friday was assigned to Alice (members[0]); Monday should be Bob (members[1]).
+	assert.Equal(t, members[1].ID, mondayAssignments[0].MemberID,
+		"Monday rotation should continue from Friday's Alice assignment, so Bob is next")
+}

--- a/internal/rota/regenerate_test.go
+++ b/internal/rota/regenerate_test.go
@@ -5,8 +5,71 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRegenerateSchedule_PreservesRotationAnchor(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	_, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+	_, err = db.AddTeamMember(ctx, "Bob", "bob@example.com")
+	require.NoError(t, err)
+	_, err = db.AddTeamMember(ctx, "Charlie", "charlie@example.com")
+	require.NoError(t, err)
+
+	maintenance := NewScheduleMaintenance(db)
+	fullStart := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	fullEnd := time.Date(2024, 1, 19, 0, 0, 0, 0, time.UTC)
+
+	created, err := maintenance.GenerateMissingDays(ctx, fullStart, fullEnd)
+	require.NoError(t, err)
+	assert.True(t, created)
+
+	targetStart := time.Date(2024, 1, 17, 0, 0, 0, 0, time.UTC)
+	targetEnd := time.Date(2024, 1, 19, 0, 0, 0, 0, time.UTC)
+
+	beforeAssignments, err := db.GetAssignmentsByDateRange(
+		ctx,
+		targetStart.Format("2006-01-02"),
+		targetEnd.Format("2006-01-02"),
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, beforeAssignments)
+
+	beforeByDate := make(map[string]string, len(beforeAssignments))
+	for _, assignment := range beforeAssignments {
+		if assignment.IsCover {
+			continue
+		}
+		beforeByDate[assignment.Date] = assignment.MemberID
+	}
+
+	count, err := maintenance.RegenerateSchedule(ctx, targetStart, targetEnd)
+	require.NoError(t, err)
+	assert.Equal(t, len(beforeByDate), count)
+
+	afterAssignments, err := db.GetAssignmentsByDateRange(
+		ctx,
+		targetStart.Format("2006-01-02"),
+		targetEnd.Format("2006-01-02"),
+	)
+	require.NoError(t, err)
+
+	afterByDate := make(map[string]string, len(afterAssignments))
+	for _, assignment := range afterAssignments {
+		if assignment.IsCover {
+			continue
+		}
+		afterByDate[assignment.Date] = assignment.MemberID
+	}
+
+	assert.Equal(t, beforeByDate, afterByDate, "regeneration should preserve the original rotation anchor")
+}
 
 // TestRegenerateScheduleWithLeave tests that regenerating a schedule from scratch
 // uses fair R2 cover rotation when leave records exist.

--- a/internal/web/calendar_handlers.go
+++ b/internal/web/calendar_handlers.go
@@ -234,8 +234,7 @@ func (h *Handler) handleCalendarICS(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 
 	// Write ICS content.
-	//nolint:gosec // Content is generated server-side and served as text/calendar.
-	_, _ = w.Write([]byte(icsContent))
+	_, _ = w.Write([]byte(icsContent)) // #nosec G705 -- ICS content is generated server-side and served as text/calendar.
 }
 
 func (h *Handler) handleMeetingsCalendarICS(w http.ResponseWriter, r *http.Request) {
@@ -283,8 +282,7 @@ func (h *Handler) handleMeetingsCalendarICS(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("Content-Disposition", "attachment; filename=\"support-meetings.ics\"")
 	w.Header().Set("Cache-Control", "no-cache")
 
-	//nolint:gosec // Content is generated server-side and served as text/calendar.
-	_, _ = w.Write([]byte(icsContent))
+	_, _ = w.Write([]byte(icsContent)) // #nosec G705 -- ICS content is generated server-side and served as text/calendar.
 }
 
 func (h *Handler) handleTeamCalendarICS(w http.ResponseWriter, r *http.Request) {
@@ -311,8 +309,7 @@ func (h *Handler) handleTeamCalendarICS(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Disposition", "attachment; filename=\"support-rota-others.ics\"")
 	w.Header().Set("Cache-Control", "no-cache")
 
-	//nolint:gosec // Content is generated server-side and served as text/calendar.
-	_, _ = w.Write([]byte(icsContent))
+	_, _ = w.Write([]byte(icsContent)) // #nosec G705 -- ICS content is generated server-side and served as text/calendar.
 }
 
 func baseURLFromRequest(r *http.Request) string {

--- a/internal/web/calendar_handlers.go
+++ b/internal/web/calendar_handlers.go
@@ -14,6 +14,8 @@ import (
 	"github.com/inful/madhatter/internal/calendar"
 )
 
+const maxCalendarFormBytes = 1 << 20
+
 // setSubscriptionURLs populates the calendar/meetings URL template data for a given token.
 func setSubscriptionURLs(r *http.Request, token string, data map[string]any) {
 	data["Token"] = token
@@ -33,12 +35,13 @@ func setSubscriptionURLs(r *http.Request, token string, data map[string]any) {
 
 // handleCalendarAdminPost handles the admin-only POST to create a subscription for another member.
 func (h *Handler) handleCalendarAdminPost(w http.ResponseWriter, r *http.Request, data map[string]any) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxCalendarFormBytes)
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	token, err := h.db.CreateCalendarSubscription(r.Context(), r.FormValue("member_id"))
+	token, err := h.db.CreateCalendarSubscription(r.Context(), r.PostForm.Get("member_id"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -231,6 +234,7 @@ func (h *Handler) handleCalendarICS(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 
 	// Write ICS content.
+	//nolint:gosec // Content is generated server-side and served as text/calendar.
 	_, _ = w.Write([]byte(icsContent))
 }
 
@@ -279,6 +283,7 @@ func (h *Handler) handleMeetingsCalendarICS(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("Content-Disposition", "attachment; filename=\"support-meetings.ics\"")
 	w.Header().Set("Cache-Control", "no-cache")
 
+	//nolint:gosec // Content is generated server-side and served as text/calendar.
 	_, _ = w.Write([]byte(icsContent))
 }
 
@@ -306,6 +311,7 @@ func (h *Handler) handleTeamCalendarICS(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Disposition", "attachment; filename=\"support-rota-others.ics\"")
 	w.Header().Set("Cache-Control", "no-cache")
 
+	//nolint:gosec // Content is generated server-side and served as text/calendar.
 	_, _ = w.Write([]byte(icsContent))
 }
 
@@ -433,13 +439,14 @@ func (h *Handler) handleCalendarSubscriptionsCleanup(w http.ResponseWriter, r *h
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxCalendarFormBytes)
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	days := defaultStaleSubscriptionDays
-	if v := strings.TrimSpace(r.FormValue("days")); v != "" {
+	if v := strings.TrimSpace(r.PostForm.Get("days")); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			days = n
 		}

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -54,10 +54,14 @@ func NewHandler(db *database.DB, authManager *auth.AuthManager, authMiddleware *
 	}
 
 	router := chi.NewRouter()
+	maintenance := rota.NewScheduleMaintenance(db)
+	if holidayChecker != nil {
+		maintenance.SetHolidayChecker(holidayChecker)
+	}
 
 	h := &Handler{
 		db:             db,
-		maintenance:    rota.NewScheduleMaintenance(db),
+		maintenance:    maintenance,
 		tmpl:           tmpl,
 		router:         router,
 		authManager:    authManager,

--- a/internal/web/handlers_leave_test.go
+++ b/internal/web/handlers_leave_test.go
@@ -54,7 +54,7 @@ func TestLeaveCreationIntegration(t *testing.T) {
 	formData.Set("end_date", time.Now().AddDate(0, 0, 5).Format("2006-01-02"))
 
 	// Create POST request
-	req := httptest.NewRequest(http.MethodPost, "/leave", strings.NewReader(formData.Encode()))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/leave", strings.NewReader(formData.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	// Create response recorder
@@ -148,7 +148,7 @@ func TestLeaveCreationWithInvalidData(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create POST request
-			req := httptest.NewRequest(http.MethodPost, "/leave", strings.NewReader(tc.formData.Encode()))
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/leave", strings.NewReader(tc.formData.Encode()))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 			// Create response recorder

--- a/internal/web/leave_handlers.go
+++ b/internal/web/leave_handlers.go
@@ -11,6 +11,8 @@ import (
 	"github.com/inful/madhatter/internal/database"
 )
 
+const maxLeaveFormBytes = 1 << 20
+
 func (h *Handler) handleLeaveReport(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	data := map[string]any{
@@ -33,6 +35,7 @@ func (h *Handler) handleLeaveReport(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handleLeaveReportPost(w http.ResponseWriter, r *http.Request, data map[string]any) {
 	ctx := r.Context()
+	r.Body = http.MaxBytesReader(w, r.Body, maxLeaveFormBytes)
 
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -40,8 +43,8 @@ func (h *Handler) handleLeaveReportPost(w http.ResponseWriter, r *http.Request, 
 	}
 
 	memberID := r.FormValue("member_id")
-	startDate := r.FormValue("start_date")
-	endDate := r.FormValue("end_date")
+	startDate := r.PostForm.Get("start_date")
+	endDate := r.PostForm.Get("end_date")
 
 	// Validate dates before hitting the database.
 	if err := validateLeaveDates(startDate, endDate); err != nil {
@@ -174,14 +177,15 @@ func (h *Handler) handleLeaveEdit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxLeaveFormBytes)
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	memberID := strings.TrimSpace(r.FormValue("member_id"))
-	startDate := strings.TrimSpace(r.FormValue("start_date"))
-	endDate := strings.TrimSpace(r.FormValue("end_date"))
+	memberID := strings.TrimSpace(r.PostForm.Get("member_id"))
+	startDate := strings.TrimSpace(r.PostForm.Get("start_date"))
+	endDate := strings.TrimSpace(r.PostForm.Get("end_date"))
 
 	// Validate input at handler level.
 	if memberID == "" {

--- a/internal/web/schedule_handlers.go
+++ b/internal/web/schedule_handlers.go
@@ -8,6 +8,8 @@ import (
 	"github.com/inful/madhatter/internal/auth"
 )
 
+const maxScheduleFormBytes = 1 << 20
+
 func (h *Handler) handleScheduleGenerate(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
 		h.handleScheduleGeneratePost(w, r)
@@ -20,6 +22,7 @@ func (h *Handler) handleScheduleGenerate(w http.ResponseWriter, r *http.Request)
 
 func (h *Handler) handleScheduleGeneratePost(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	r.Body = http.MaxBytesReader(w, r.Body, maxScheduleFormBytes)
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -37,7 +40,7 @@ func (h *Handler) handleScheduleGeneratePost(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Generate schedule based on mode.
-	regenerate := r.FormValue("regenerate") == "on"
+	regenerate := r.PostForm.Get("regenerate") == "on"
 	var err error
 	if regenerate {
 		_, err = h.maintenance.RegenerateSchedule(ctx, start, end)
@@ -92,8 +95,8 @@ func (h *Handler) validateTeamMembers(ctx context.Context, w http.ResponseWriter
 }
 
 func (h *Handler) parseDateRange(w http.ResponseWriter, r *http.Request) (time.Time, time.Time, bool) {
-	startDate := r.FormValue("start_date")
-	endDate := r.FormValue("end_date")
+	startDate := r.PostForm.Get("start_date")
+	endDate := r.PostForm.Get("end_date")
 
 	start, err := time.Parse("2006-01-02", startDate)
 	if err != nil {

--- a/internal/web/team_handlers.go
+++ b/internal/web/team_handlers.go
@@ -14,15 +14,18 @@ import (
 	"github.com/inful/madhatter/internal/database/sqlc"
 )
 
+const maxTeamFormBytes = 1 << 20
+
 func (h *Handler) handleTeamPost(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxTeamFormBytes)
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	_, err := h.db.AddTeamMember(ctx, r.FormValue("name"), r.FormValue("email"))
+	_, err := h.db.AddTeamMember(ctx, r.PostForm.Get("name"), r.PostForm.Get("email"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -119,13 +122,14 @@ func (h *Handler) handleTeamMemberEdit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxTeamFormBytes)
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	name := strings.TrimSpace(r.FormValue("name"))
-	email := strings.TrimSpace(r.FormValue("email"))
+	name := strings.TrimSpace(r.PostForm.Get("name"))
+	email := strings.TrimSpace(r.PostForm.Get("email"))
 
 	// Validate input at handler level.
 	if err := validateTeamMemberInput(name, email); err != nil {
@@ -168,12 +172,13 @@ func (h *Handler) handleUserAdminUpdate(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxTeamFormBytes)
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	makeAdmin := r.FormValue("is_admin") == "1"
+	makeAdmin := r.PostForm.Get("is_admin") == "1"
 	user, err := h.db.GetQueries().GetUserByID(ctx, userID)
 	if errors.Is(err, sql.ErrNoRows) {
 		http.Error(w, "user not found", http.StatusNotFound)

--- a/internal/web/team_handlers_test.go
+++ b/internal/web/team_handlers_test.go
@@ -114,7 +114,7 @@ func buildAdminUpdateRequest(userID, isAdminFormValue string) *http.Request {
 	form := url.Values{}
 	form.Set("is_admin", isAdminFormValue)
 
-	req := httptest.NewRequest(http.MethodPost, "/team/users/"+userID+"/admin", strings.NewReader(form.Encode()))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/team/users/"+userID+"/admin", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	routeCtx := chi.NewRouteContext()


### PR DESCRIPTION
## Summary
- propagate the holiday checker into web and API schedule maintenance so holiday dates are skipped when assignments are generated
- add regression coverage for holiday-skipping assignment generation
- preserve the existing rotation anchor when regenerating a schedule range so regenerated dates keep the prior ordering

## Validation
- go test ./internal/rota -run 'TestScheduleMaintenance'
- go test ./internal/rota -run 'TestRegenerateSchedule|TestRegenerateWithMultipleLeaves'
- go test ./internal/rota
- go test ./internal/web ./internal/api