### PR TITLE
refactor(swaps): centralise swap business rules in database package

### DIFF
--- a/internal/api/handlers_swaps.go
+++ b/internal/api/handlers_swaps.go
@@ -10,10 +10,6 @@ import (
 	"github.com/inful/madhatter/internal/database"
 )
 
-const (
-	apiSwapStatusPending = "pending"
-)
-
 // -- Input/Output types -------------------------------------------------------
 
 type CreateSwapInput struct {
@@ -77,51 +73,38 @@ func (s *Server) validateSwapAssignmentsAPI(
 	ctx context.Context,
 	reqAssignmentID, tgtAssignmentID, memberID string,
 ) (*database.RotaAssignment, *database.RotaAssignment, error) {
-	if reqAssignmentID == tgtAssignmentID {
-		return nil, nil, huma.Error422UnprocessableEntity("Cannot swap an assignment with itself", nil)
-	}
-
-	reqAssignment, err := s.db.GetAssignmentByID(ctx, reqAssignmentID)
+	reqAssignment, tgtAssignment, err := s.db.ValidateSwapAssignments(ctx, reqAssignmentID, tgtAssignmentID, memberID)
 	if err != nil {
-		return nil, nil, huma.Error422UnprocessableEntity("Requester assignment not found", nil)
-	}
-
-	tgtAssignment, err := s.db.GetAssignmentByID(ctx, tgtAssignmentID)
-	if err != nil {
-		return nil, nil, huma.Error422UnprocessableEntity("Target assignment not found", nil)
-	}
-
-	if reqAssignment.MemberID != memberID {
-		return nil, nil, huma.Error403Forbidden("You can only swap your own assignments")
-	}
-
-	if tgtAssignment.MemberID == reqAssignment.MemberID {
-		return nil, nil, huma.Error422UnprocessableEntity("Swap target must belong to another member", nil)
-	}
-
-	nowUTC := time.Now().UTC()
-	today := time.Date(nowUTC.Year(), nowUTC.Month(), nowUTC.Day(), 0, 0, 0, 0, time.UTC)
-
-	reqDate, parseErr := time.Parse("2006-01-02", reqAssignment.Date)
-	if parseErr != nil || reqDate.Before(today) {
-		return nil, nil, huma.Error422UnprocessableEntity("Your HAT day has already passed and cannot be swapped", nil)
-	}
-
-	tgtDate, parseErr := time.Parse("2006-01-02", tgtAssignment.Date)
-	if parseErr != nil || tgtDate.Before(today) {
-		return nil, nil, huma.Error422UnprocessableEntity("The target HAT day has already passed and cannot be swapped", nil)
+		return nil, nil, swapDomainToHumaError(err)
 	}
 
 	return reqAssignment, tgtAssignment, nil
 }
 
+// swapDomainToHumaError converts a domain validation error into the appropriate huma error.
+func swapDomainToHumaError(err error) error {
+	switch {
+	case errors.Is(err, database.ErrSwapSameAssignment):
+		return huma.Error422UnprocessableEntity(err.Error(), nil)
+	case errors.Is(err, database.ErrRequesterAssignmentNotFound),
+		errors.Is(err, database.ErrTargetAssignmentNotFound):
+		return huma.Error422UnprocessableEntity(err.Error(), nil)
+	case errors.Is(err, database.ErrSwapNotOwner):
+		return huma.Error403Forbidden(err.Error())
+	case errors.Is(err, database.ErrSwapTargetSelf):
+		return huma.Error422UnprocessableEntity(err.Error(), nil)
+	case errors.Is(err, database.ErrSwapRequesterDatePassed),
+		errors.Is(err, database.ErrSwapTargetDatePassed):
+		return huma.Error422UnprocessableEntity(err.Error(), nil)
+	default:
+		return huma.Error422UnprocessableEntity(err.Error(), nil)
+	}
+}
+
 // checkNoOpenSwaps returns an error if either assignment already has a pending swap.
 func (s *Server) checkNoOpenSwaps(ctx context.Context, reqAssignmentID, tgtAssignmentID string) error {
-	for _, aid := range []string{reqAssignmentID, tgtAssignmentID} {
-		existing, lookupErr := s.db.GetOpenSwapForAssignment(ctx, aid)
-		if lookupErr == nil && existing != nil {
-			return huma.Error409Conflict("One of the assignments already has an open swap request")
-		}
+	if err := s.db.CheckNoOpenSwaps(ctx, reqAssignmentID, tgtAssignmentID); err != nil {
+		return huma.Error409Conflict(err.Error())
 	}
 
 	return nil
@@ -232,7 +215,7 @@ func (s *Server) handleAcceptSwap(ctx context.Context, input *SwapIDInput) (*Swa
 		return nil, huma.Error403Forbidden("Only the target member can accept this swap")
 	}
 
-	if swap.Status != apiSwapStatusPending {
+	if swap.Status != database.SwapStatusPending {
 		return nil, huma.Error409Conflict("Swap is no longer pending")
 	}
 
@@ -269,11 +252,11 @@ func (s *Server) handleRejectSwap(ctx context.Context, input *SwapIDInput) (*Swa
 		return nil, huma.Error403Forbidden("Only the target member can reject this swap")
 	}
 
-	if swap.Status != apiSwapStatusPending {
+	if swap.Status != database.SwapStatusPending {
 		return nil, huma.Error409Conflict("Swap is no longer pending")
 	}
 
-	if err := s.db.UpdateHatSwapStatus(ctx, input.ID, "rejected"); err != nil {
+	if err := s.db.UpdateHatSwapStatus(ctx, input.ID, database.SwapStatusRejected); err != nil {
 		if errors.Is(err, database.ErrSwapNotPending) {
 			return nil, huma.Error409Conflict("Swap is no longer pending")
 		}
@@ -306,11 +289,11 @@ func (s *Server) handleCancelSwap(ctx context.Context, input *SwapIDInput) (*Swa
 		return nil, huma.Error403Forbidden("Only the requester can cancel this swap")
 	}
 
-	if swap.Status != apiSwapStatusPending {
+	if swap.Status != database.SwapStatusPending {
 		return nil, huma.Error409Conflict("Swap is no longer pending")
 	}
 
-	if err := s.db.UpdateHatSwapStatus(ctx, input.ID, "cancelled"); err != nil {
+	if err := s.db.UpdateHatSwapStatus(ctx, input.ID, database.SwapStatusCancelled); err != nil {
 		if errors.Is(err, database.ErrSwapNotPending) {
 			return nil, huma.Error409Conflict("Swap is no longer pending")
 		}

--- a/internal/api/handlers_swaps.go
+++ b/internal/api/handlers_swaps.go
@@ -97,14 +97,18 @@ func swapDomainToHumaError(err error) error {
 		errors.Is(err, database.ErrSwapTargetDatePassed):
 		return huma.Error422UnprocessableEntity(err.Error(), nil)
 	default:
-		return huma.Error422UnprocessableEntity(err.Error(), nil)
+		return huma.Error500InternalServerError("An unexpected error occurred", err)
 	}
 }
 
 // checkNoOpenSwaps returns an error if either assignment already has a pending swap.
 func (s *Server) checkNoOpenSwaps(ctx context.Context, reqAssignmentID, tgtAssignmentID string) error {
 	if err := s.db.CheckNoOpenSwaps(ctx, reqAssignmentID, tgtAssignmentID); err != nil {
-		return huma.Error409Conflict(err.Error())
+		if errors.Is(err, database.ErrSwapAssignmentBusy) {
+			return huma.Error409Conflict(err.Error())
+		}
+
+		return huma.Error500InternalServerError("Failed to check for open swaps", err)
 	}
 
 	return nil

--- a/internal/database/hat_swaps.go
+++ b/internal/database/hat_swaps.go
@@ -10,12 +10,91 @@ import (
 	"github.com/ncruces/go-sqlite3"
 )
 
-var (
-	ErrSwapNotPending     = errors.New("swap is no longer pending")
-	ErrSwapDatePassed     = errors.New("one of the HAT days has already passed and cannot be swapped")
-	ErrSwapSameMember     = errors.New("swap target must belong to another member")
-	ErrSwapAssignmentBusy = errors.New("one of the assignments already has an open swap request")
+// Swap status constants shared across the application.
+const (
+	SwapStatusPending   = "pending"
+	SwapStatusAccepted  = "accepted"
+	SwapStatusRejected  = "rejected"
+	SwapStatusCancelled = "cancelled"
 )
+
+var (
+	ErrSwapNotPending              = errors.New("swap is no longer pending")
+	ErrSwapDatePassed              = errors.New("one of the HAT days has already passed and cannot be swapped")
+	ErrSwapSameMember              = errors.New("swap target must belong to another member")
+	ErrSwapAssignmentBusy          = errors.New("one of the assignments already has an open swap request")
+	ErrSwapSameAssignment          = errors.New("cannot swap an assignment with itself")
+	ErrSwapNotOwner                = errors.New("you can only swap your own assignments")
+	ErrSwapTargetSelf              = errors.New("swap target must belong to another member")
+	ErrRequesterAssignmentNotFound = errors.New("requester assignment not found")
+	ErrTargetAssignmentNotFound    = errors.New("target assignment not found")
+	ErrSwapRequesterDatePassed     = errors.New("your HAT day has already passed and cannot be swapped")
+	ErrSwapTargetDatePassed        = errors.New("the target HAT day has already passed and cannot be swapped")
+)
+
+// ValidateSwapAssignments checks that both assignments exist, the requester owns their
+// assignment, the target belongs to a different member, and both dates are in the future.
+// It returns the two resolved assignments when all checks pass.
+func (db *DB) ValidateSwapAssignments(ctx context.Context, requesterAssignmentID, targetAssignmentID, requesterMemberID string) (*RotaAssignment, *RotaAssignment, error) {
+	if requesterAssignmentID == targetAssignmentID {
+		return nil, nil, ErrSwapSameAssignment
+	}
+
+	reqAssignment, err := db.GetAssignmentByID(ctx, requesterAssignmentID)
+	if err != nil || reqAssignment == nil {
+		return nil, nil, ErrRequesterAssignmentNotFound
+	}
+
+	tgtAssignment, err := db.GetAssignmentByID(ctx, targetAssignmentID)
+	if err != nil || tgtAssignment == nil {
+		return nil, nil, ErrTargetAssignmentNotFound
+	}
+
+	if reqAssignment.MemberID != requesterMemberID {
+		return nil, nil, ErrSwapNotOwner
+	}
+
+	if tgtAssignment.MemberID == reqAssignment.MemberID {
+		return nil, nil, ErrSwapTargetSelf
+	}
+
+	if err = validateSwapAssignmentDates(reqAssignment.Date, tgtAssignment.Date); err != nil {
+		return nil, nil, err
+	}
+
+	return reqAssignment, tgtAssignment, nil
+}
+
+// validateSwapAssignmentDates checks that both assignment dates are in the future.
+func validateSwapAssignmentDates(reqDate, tgtDate string) error {
+	nowUTC := time.Now().UTC()
+	today := time.Date(nowUTC.Year(), nowUTC.Month(), nowUTC.Day(), 0, 0, 0, 0, time.UTC)
+
+	req, err := time.Parse("2006-01-02", reqDate)
+	if err != nil || req.Before(today) {
+		return ErrSwapRequesterDatePassed
+	}
+
+	tgt, err := time.Parse("2006-01-02", tgtDate)
+	if err != nil || tgt.Before(today) {
+		return ErrSwapTargetDatePassed
+	}
+
+	return nil
+}
+
+// CheckNoOpenSwaps returns ErrSwapAssignmentBusy if any of the given assignments
+// already has a pending swap request.
+func (db *DB) CheckNoOpenSwaps(ctx context.Context, assignmentIDs ...string) error {
+	for _, aid := range assignmentIDs {
+		existing, err := db.GetOpenSwapForAssignment(ctx, aid)
+		if err == nil && existing != nil {
+			return ErrSwapAssignmentBusy
+		}
+	}
+
+	return nil
+}
 
 // CreateHatSwap creates a new pending HAT day swap request.
 func (db *DB) CreateHatSwap(ctx context.Context, requesterAssignmentID, targetAssignmentID, requesterMemberID, targetMemberID string) (string, error) {

--- a/internal/database/hat_swaps.go
+++ b/internal/database/hat_swaps.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"time"
 
@@ -30,6 +31,8 @@ var (
 	ErrTargetAssignmentNotFound    = errors.New("target assignment not found")
 	ErrSwapRequesterDatePassed     = errors.New("your HAT day has already passed and cannot be swapped")
 	ErrSwapTargetDatePassed        = errors.New("the target HAT day has already passed and cannot be swapped")
+	ErrSwapRequesterDateInvalid    = errors.New("requester assignment date is invalid")
+	ErrSwapTargetDateInvalid       = errors.New("target assignment date is invalid")
 )
 
 // ValidateSwapAssignments checks that both assignments exist, the requester owns their
@@ -41,13 +44,21 @@ func (db *DB) ValidateSwapAssignments(ctx context.Context, requesterAssignmentID
 	}
 
 	reqAssignment, err := db.GetAssignmentByID(ctx, requesterAssignmentID)
-	if err != nil || reqAssignment == nil {
-		return nil, nil, ErrRequesterAssignmentNotFound
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, ErrRequesterAssignmentNotFound
+		}
+
+		return nil, nil, err
 	}
 
 	tgtAssignment, err := db.GetAssignmentByID(ctx, targetAssignmentID)
-	if err != nil || tgtAssignment == nil {
-		return nil, nil, ErrTargetAssignmentNotFound
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, ErrTargetAssignmentNotFound
+		}
+
+		return nil, nil, err
 	}
 
 	if reqAssignment.MemberID != requesterMemberID {
@@ -71,12 +82,20 @@ func validateSwapAssignmentDates(reqDate, tgtDate string) error {
 	today := time.Date(nowUTC.Year(), nowUTC.Month(), nowUTC.Day(), 0, 0, 0, 0, time.UTC)
 
 	req, err := time.Parse("2006-01-02", reqDate)
-	if err != nil || req.Before(today) {
+	if err != nil {
+		return ErrSwapRequesterDateInvalid
+	}
+
+	if req.Before(today) {
 		return ErrSwapRequesterDatePassed
 	}
 
 	tgt, err := time.Parse("2006-01-02", tgtDate)
-	if err != nil || tgt.Before(today) {
+	if err != nil {
+		return ErrSwapTargetDateInvalid
+	}
+
+	if tgt.Before(today) {
 		return ErrSwapTargetDatePassed
 	}
 
@@ -88,7 +107,15 @@ func validateSwapAssignmentDates(reqDate, tgtDate string) error {
 func (db *DB) CheckNoOpenSwaps(ctx context.Context, assignmentIDs ...string) error {
 	for _, aid := range assignmentIDs {
 		existing, err := db.GetOpenSwapForAssignment(ctx, aid)
-		if err == nil && existing != nil {
+		if err != nil {
+			if !errors.Is(err, sql.ErrNoRows) {
+				return err
+			}
+
+			continue
+		}
+
+		if existing != nil {
 			return ErrSwapAssignmentBusy
 		}
 	}
@@ -214,7 +241,7 @@ func (db *DB) ExecuteSwap(ctx context.Context, swapID string) (retErr error) {
 		return err
 	}
 
-	if swap.Status != "pending" {
+	if swap.Status != SwapStatusPending {
 		return ErrSwapNotPending
 	}
 
@@ -260,7 +287,7 @@ func (db *DB) executeSwapTx(ctx context.Context, qtx *sqlc.Queries, reqAssignmen
 	}
 
 	result, err := qtx.UpdateHatSwapStatus(ctx, sqlc.UpdateHatSwapStatusParams{
-		Status: "accepted",
+		Status: SwapStatusAccepted,
 		ID:     swapID,
 	})
 	if err != nil {

--- a/internal/database/hat_swaps_test.go
+++ b/internal/database/hat_swaps_test.go
@@ -67,3 +67,270 @@ func TestExecuteSwap_RejectsPastAssignments(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, bobID, bobAssignment.MemberID)
 }
+
+// ---------------------------------------------------------------------------
+// ValidateSwapAssignments
+// ---------------------------------------------------------------------------
+
+func TestValidateSwapAssignments_SameAssignment_ReturnsErrSwapSameAssignment(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	aliceID, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+
+	date := time.Now().AddDate(0, 0, 7).Format("2006-01-02")
+	assignmentID, err := db.CreateRotaAssignment(ctx, date, aliceID, false, nil)
+	require.NoError(t, err)
+
+	_, _, err = db.ValidateSwapAssignments(ctx, assignmentID, assignmentID, aliceID)
+	require.ErrorIs(t, err, ErrSwapSameAssignment)
+}
+
+func TestValidateSwapAssignments_RequesterNotFound_ReturnsErrRequesterAssignmentNotFound(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	aliceID, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+	bobID, err := db.AddTeamMember(ctx, "Bob", "bob@example.com")
+	require.NoError(t, err)
+
+	date := time.Now().AddDate(0, 0, 7).Format("2006-01-02")
+	bobAssignmentID, err := db.CreateRotaAssignment(ctx, date, bobID, false, nil)
+	require.NoError(t, err)
+
+	_, _, err = db.ValidateSwapAssignments(ctx, "nonexistent-id", bobAssignmentID, aliceID)
+	require.ErrorIs(t, err, ErrRequesterAssignmentNotFound)
+}
+
+func TestValidateSwapAssignments_TargetNotFound_ReturnsErrTargetAssignmentNotFound(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	aliceID, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+
+	date := time.Now().AddDate(0, 0, 7).Format("2006-01-02")
+	aliceAssignmentID, err := db.CreateRotaAssignment(ctx, date, aliceID, false, nil)
+	require.NoError(t, err)
+
+	_, _, err = db.ValidateSwapAssignments(ctx, aliceAssignmentID, "nonexistent-id", aliceID)
+	require.ErrorIs(t, err, ErrTargetAssignmentNotFound)
+}
+
+func TestValidateSwapAssignments_NotOwner_ReturnsErrSwapNotOwner(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	aliceID, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+	bobID, err := db.AddTeamMember(ctx, "Bob", "bob@example.com")
+	require.NoError(t, err)
+	charlieID, err := db.AddTeamMember(ctx, "Charlie", "charlie@example.com")
+	require.NoError(t, err)
+
+	baseDate := time.Now().AddDate(0, 0, 7)
+	aliceAssignmentID, err := db.CreateRotaAssignment(ctx, baseDate.Format("2006-01-02"), aliceID, false, nil)
+	require.NoError(t, err)
+	bobAssignmentID, err := db.CreateRotaAssignment(ctx, baseDate.AddDate(0, 0, 1).Format("2006-01-02"), bobID, false, nil)
+	require.NoError(t, err)
+
+	// Charlie tries to swap Alice's assignment
+	_, _, err = db.ValidateSwapAssignments(ctx, aliceAssignmentID, bobAssignmentID, charlieID)
+	require.ErrorIs(t, err, ErrSwapNotOwner)
+}
+
+func TestValidateSwapAssignments_SelfTarget_ReturnsErrSwapTargetSelf(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	aliceID, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+
+	baseDate := time.Now().AddDate(0, 0, 7)
+	a1, err := db.CreateRotaAssignment(ctx, baseDate.Format("2006-01-02"), aliceID, false, nil)
+	require.NoError(t, err)
+	a2, err := db.CreateRotaAssignment(ctx, baseDate.AddDate(0, 0, 1).Format("2006-01-02"), aliceID, false, nil)
+	require.NoError(t, err)
+
+	_, _, err = db.ValidateSwapAssignments(ctx, a1, a2, aliceID)
+	require.ErrorIs(t, err, ErrSwapTargetSelf)
+}
+
+func TestValidateSwapAssignments_RequesterDatePassed_ReturnsErrSwapRequesterDatePassed(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	aliceID, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+	bobID, err := db.AddTeamMember(ctx, "Bob", "bob@example.com")
+	require.NoError(t, err)
+
+	pastDate := time.Now().AddDate(0, 0, -3).Format("2006-01-02")
+	futureDate := time.Now().AddDate(0, 0, 7).Format("2006-01-02")
+	aliceAssignmentID, err := db.CreateRotaAssignment(ctx, pastDate, aliceID, false, nil)
+	require.NoError(t, err)
+	bobAssignmentID, err := db.CreateRotaAssignment(ctx, futureDate, bobID, false, nil)
+	require.NoError(t, err)
+
+	_, _, err = db.ValidateSwapAssignments(ctx, aliceAssignmentID, bobAssignmentID, aliceID)
+	require.ErrorIs(t, err, ErrSwapRequesterDatePassed)
+}
+
+func TestValidateSwapAssignments_TargetDatePassed_ReturnsErrSwapTargetDatePassed(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	aliceID, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+	bobID, err := db.AddTeamMember(ctx, "Bob", "bob@example.com")
+	require.NoError(t, err)
+
+	futureDate := time.Now().AddDate(0, 0, 7).Format("2006-01-02")
+	pastDate := time.Now().AddDate(0, 0, -3).Format("2006-01-02")
+	aliceAssignmentID, err := db.CreateRotaAssignment(ctx, futureDate, aliceID, false, nil)
+	require.NoError(t, err)
+	bobAssignmentID, err := db.CreateRotaAssignment(ctx, pastDate, bobID, false, nil)
+	require.NoError(t, err)
+
+	_, _, err = db.ValidateSwapAssignments(ctx, aliceAssignmentID, bobAssignmentID, aliceID)
+	require.ErrorIs(t, err, ErrSwapTargetDatePassed)
+}
+
+func TestValidateSwapAssignments_Valid_ReturnsAssignments(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	aliceID, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+	bobID, err := db.AddTeamMember(ctx, "Bob", "bob@example.com")
+	require.NoError(t, err)
+
+	baseDate := time.Now().AddDate(0, 0, 7)
+	aliceAssignmentID, err := db.CreateRotaAssignment(ctx, baseDate.Format("2006-01-02"), aliceID, false, nil)
+	require.NoError(t, err)
+	bobAssignmentID, err := db.CreateRotaAssignment(ctx, baseDate.AddDate(0, 0, 1).Format("2006-01-02"), bobID, false, nil)
+	require.NoError(t, err)
+
+	reqA, tgtA, err := db.ValidateSwapAssignments(ctx, aliceAssignmentID, bobAssignmentID, aliceID)
+	require.NoError(t, err)
+	assert.Equal(t, aliceAssignmentID, reqA.ID)
+	assert.Equal(t, bobAssignmentID, tgtA.ID)
+}
+
+// ---------------------------------------------------------------------------
+// validateSwapAssignmentDates
+// ---------------------------------------------------------------------------
+
+func TestValidateSwapAssignmentDates_InvalidRequesterDate_ReturnsErrSwapRequesterDateInvalid(t *testing.T) {
+	err := validateSwapAssignmentDates("not-a-date", time.Now().AddDate(0, 0, 7).Format("2006-01-02"))
+	require.ErrorIs(t, err, ErrSwapRequesterDateInvalid)
+}
+
+func TestValidateSwapAssignmentDates_InvalidTargetDate_ReturnsErrSwapTargetDateInvalid(t *testing.T) {
+	err := validateSwapAssignmentDates(time.Now().AddDate(0, 0, 7).Format("2006-01-02"), "not-a-date")
+	require.ErrorIs(t, err, ErrSwapTargetDateInvalid)
+}
+
+func TestValidateSwapAssignmentDates_RequesterDateInPast_ReturnsErrSwapRequesterDatePassed(t *testing.T) {
+	past := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+	future := time.Now().AddDate(0, 0, 7).Format("2006-01-02")
+	err := validateSwapAssignmentDates(past, future)
+	require.ErrorIs(t, err, ErrSwapRequesterDatePassed)
+}
+
+func TestValidateSwapAssignmentDates_TargetDateInPast_ReturnsErrSwapTargetDatePassed(t *testing.T) {
+	future := time.Now().AddDate(0, 0, 7).Format("2006-01-02")
+	past := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+	err := validateSwapAssignmentDates(future, past)
+	require.ErrorIs(t, err, ErrSwapTargetDatePassed)
+}
+
+func TestValidateSwapAssignmentDates_BothFuture_ReturnsNil(t *testing.T) {
+	future1 := time.Now().AddDate(0, 0, 7).Format("2006-01-02")
+	future2 := time.Now().AddDate(0, 0, 14).Format("2006-01-02")
+	err := validateSwapAssignmentDates(future1, future2)
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// CheckNoOpenSwaps
+// ---------------------------------------------------------------------------
+
+func TestCheckNoOpenSwaps_NoOpenSwap_ReturnsNil(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	aliceID, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+
+	date := time.Now().AddDate(0, 0, 7).Format("2006-01-02")
+	assignmentID, err := db.CreateRotaAssignment(ctx, date, aliceID, false, nil)
+	require.NoError(t, err)
+
+	err = db.CheckNoOpenSwaps(ctx, assignmentID)
+	require.NoError(t, err)
+}
+
+func TestCheckNoOpenSwaps_OpenSwapExists_ReturnsErrSwapAssignmentBusy(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	aliceID, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+	bobID, err := db.AddTeamMember(ctx, "Bob", "bob@example.com")
+	require.NoError(t, err)
+
+	baseDate := time.Now().AddDate(0, 0, 7)
+	aliceAssignmentID, err := db.CreateRotaAssignment(ctx, baseDate.Format("2006-01-02"), aliceID, false, nil)
+	require.NoError(t, err)
+	bobAssignmentID, err := db.CreateRotaAssignment(ctx, baseDate.AddDate(0, 0, 1).Format("2006-01-02"), bobID, false, nil)
+	require.NoError(t, err)
+
+	_, err = db.CreateHatSwap(ctx, aliceAssignmentID, bobAssignmentID, aliceID, bobID)
+	require.NoError(t, err)
+
+	err = db.CheckNoOpenSwaps(ctx, aliceAssignmentID)
+	require.ErrorIs(t, err, ErrSwapAssignmentBusy)
+}
+
+func TestCheckNoOpenSwaps_SecondAssignmentBusy_ReturnsErrSwapAssignmentBusy(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	aliceID, err := db.AddTeamMember(ctx, "Alice", "alice@example.com")
+	require.NoError(t, err)
+	bobID, err := db.AddTeamMember(ctx, "Bob", "bob@example.com")
+	require.NoError(t, err)
+	charlieID, err := db.AddTeamMember(ctx, "Charlie", "charlie@example.com")
+	require.NoError(t, err)
+
+	baseDate := time.Now().AddDate(0, 0, 7)
+	aliceAssignmentID, err := db.CreateRotaAssignment(ctx, baseDate.Format("2006-01-02"), aliceID, false, nil)
+	require.NoError(t, err)
+	bobAssignmentID, err := db.CreateRotaAssignment(ctx, baseDate.AddDate(0, 0, 1).Format("2006-01-02"), bobID, false, nil)
+	require.NoError(t, err)
+	charlieAssignmentID, err := db.CreateRotaAssignment(ctx, baseDate.AddDate(0, 0, 2).Format("2006-01-02"), charlieID, false, nil)
+	require.NoError(t, err)
+
+	// Bob's assignment has an open swap with Charlie.
+	_, err = db.CreateHatSwap(ctx, bobAssignmentID, charlieAssignmentID, bobID, charlieID)
+	require.NoError(t, err)
+
+	// Alice tries a swap involving her (free) assignment and Bob's (busy) assignment.
+	err = db.CheckNoOpenSwaps(ctx, aliceAssignmentID, bobAssignmentID)
+	require.ErrorIs(t, err, ErrSwapAssignmentBusy)
+}
+

--- a/internal/database/hat_swaps_test.go
+++ b/internal/database/hat_swaps_test.go
@@ -333,4 +333,3 @@ func TestCheckNoOpenSwaps_SecondAssignmentBusy_ReturnsErrSwapAssignmentBusy(t *t
 	err = db.CheckNoOpenSwaps(ctx, aliceAssignmentID, bobAssignmentID)
 	require.ErrorIs(t, err, ErrSwapAssignmentBusy)
 }
-

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -1,6 +1,24 @@
 package web
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+
+	"github.com/inful/madhatter/internal/auth"
+	"github.com/inful/madhatter/internal/database/sqlc"
+)
+
+// mustGetUser returns the authenticated user from the context.
+// It panics if no user is present, which means a route was reached without
+// going through safeRequireAuth middleware — a programming error.
+func mustGetUser(ctx context.Context) *sqlc.GetSessionByTokenRow {
+	user, ok := auth.GetUserFromContext(ctx)
+	if !ok {
+		panic("mustGetUser: no authenticated user in context — missing safeRequireAuth middleware on this route")
+	}
+
+	return user
+}
 
 // safeAuthMiddleware wraps middleware to handle nil auth components gracefully.
 func (h *Handler) safeAuthMiddleware(next http.Handler) http.Handler {

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -1,0 +1,39 @@
+package web
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"testing"
+
+	"github.com/inful/madhatter/internal/auth"
+	"github.com/inful/madhatter/internal/database/sqlc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMustGetUser_UserInContext_ReturnsUser(t *testing.T) {
+	row := &sqlc.GetSessionByTokenRow{
+		Email:   "alice@example.com",
+		Name:    "Alice",
+		IsAdmin: sql.NullInt64{Int64: 0, Valid: true},
+	}
+
+	ctx := context.WithValue(context.Background(), auth.UserContextKey, row)
+	r, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+	require.NoError(t, err)
+
+	got := mustGetUser(r.Context())
+
+	assert.Equal(t, "alice@example.com", got.Email)
+	assert.Equal(t, "Alice", got.Name)
+}
+
+func TestMustGetUser_NoUserInContext_Panics(t *testing.T) {
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	require.NoError(t, err)
+
+	assert.Panics(t, func() {
+		mustGetUser(r.Context())
+	})
+}

--- a/internal/web/swap_handlers.go
+++ b/internal/web/swap_handlers.go
@@ -74,7 +74,12 @@ func (h *Handler) handleSwapRequestPost(w http.ResponseWriter, r *http.Request, 
 	}
 
 	if err = h.db.CheckNoOpenSwaps(ctx, requesterAssignmentID, targetAssignmentID); err != nil {
-		h.renderSwapsPage(w, r, data, memberID, "One of the selected assignments already has an open swap request.")
+		if errors.Is(err, database.ErrSwapAssignmentBusy) {
+			h.renderSwapsPage(w, r, data, memberID, "One of the selected assignments already has an open swap request.")
+		} else {
+			http.Error(w, "An unexpected error occurred.", http.StatusInternalServerError)
+		}
+
 		return
 	}
 
@@ -103,8 +108,12 @@ func swapValidationErrorMessage(err error) string {
 		return "Your HAT day has already passed and cannot be swapped."
 	case errors.Is(err, database.ErrSwapTargetDatePassed):
 		return "The target HAT day has already passed and cannot be swapped."
+	case errors.Is(err, database.ErrSwapRequesterDateInvalid):
+		return "Your assignment date is invalid."
+	case errors.Is(err, database.ErrSwapTargetDateInvalid):
+		return "The target assignment date is invalid."
 	default:
-		return err.Error()
+		return "An unexpected error occurred."
 	}
 }
 

--- a/internal/web/swap_handlers.go
+++ b/internal/web/swap_handlers.go
@@ -4,18 +4,10 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/inful/madhatter/internal/auth"
 	"github.com/inful/madhatter/internal/database"
-)
-
-const (
-	swapStatusPending   = "pending"
-	swapStatusAccepted  = "accepted"
-	swapStatusRejected  = "rejected"
-	swapStatusCancelled = "cancelled"
 )
 
 // resolveMemberID resolves the team member ID for the currently logged-in user.
@@ -75,24 +67,23 @@ func (h *Handler) handleSwapRequestPost(w http.ResponseWriter, r *http.Request, 
 	requesterAssignmentID := r.FormValue("requester_assignment_id")
 	targetAssignmentID := r.FormValue("target_assignment_id")
 
-	if errMsg := h.validateSwapRequest(ctx, requesterAssignmentID, targetAssignmentID, memberID); errMsg != "" {
-		h.renderSwapsPage(w, r, data, memberID, errMsg)
+	if requesterAssignmentID == "" || targetAssignmentID == "" {
+		h.renderSwapsPage(w, r, data, memberID, "Please select both assignments.")
 		return
 	}
 
-	reqAssignment, err := h.db.GetAssignmentByID(ctx, requesterAssignmentID)
-	if err != nil || reqAssignment == nil {
-		h.renderSwapsPage(w, r, data, memberID, "The selected requester assignment is no longer available.")
+	reqAssignment, tgtAssignment, err := h.db.ValidateSwapAssignments(ctx, requesterAssignmentID, targetAssignmentID, memberID)
+	if err != nil {
+		h.renderSwapsPage(w, r, data, memberID, swapValidationErrorMessage(err))
 		return
 	}
 
-	tgtAssignment, err := h.db.GetAssignmentByID(ctx, targetAssignmentID)
-	if err != nil || tgtAssignment == nil {
-		h.renderSwapsPage(w, r, data, memberID, "The selected target assignment is no longer available.")
+	if err = h.db.CheckNoOpenSwaps(ctx, requesterAssignmentID, targetAssignmentID); err != nil {
+		h.renderSwapsPage(w, r, data, memberID, "One of the selected assignments already has an open swap request.")
 		return
 	}
 
-	if _, err := h.db.CreateHatSwap(ctx, requesterAssignmentID, targetAssignmentID, reqAssignment.MemberID, tgtAssignment.MemberID); err != nil {
+	if _, err = h.db.CreateHatSwap(ctx, requesterAssignmentID, targetAssignmentID, reqAssignment.MemberID, tgtAssignment.MemberID); err != nil {
 		h.renderSwapsPage(w, r, data, memberID, err.Error())
 		return
 	}
@@ -100,68 +91,26 @@ func (h *Handler) handleSwapRequestPost(w http.ResponseWriter, r *http.Request, 
 	http.Redirect(w, r, "/swaps", http.StatusSeeOther)
 }
 
-// validateSwapRequest validates the swap inputs and returns an error message if invalid.
-func (h *Handler) validateSwapRequest(ctx context.Context, requesterAssignmentID, targetAssignmentID, userID string) string {
-	if requesterAssignmentID == "" || targetAssignmentID == "" {
-		return "Please select both assignments."
-	}
-
-	if requesterAssignmentID == targetAssignmentID {
+// swapValidationErrorMessage maps domain errors from ValidateSwapAssignments to user-facing messages.
+func swapValidationErrorMessage(err error) string {
+	switch {
+	case errors.Is(err, database.ErrSwapSameAssignment):
 		return "Cannot swap an assignment with itself."
-	}
-
-	if msg := h.validateSwapAssignments(ctx, requesterAssignmentID, targetAssignmentID, userID); msg != "" {
-		return msg
-	}
-
-	for _, assignmentID := range []string{requesterAssignmentID, targetAssignmentID} {
-		existing, lookupErr := h.db.GetOpenSwapForAssignment(ctx, assignmentID)
-		if lookupErr == nil && existing != nil {
-			return "One of the selected assignments already has an open swap request."
-		}
-	}
-
-	return ""
-}
-
-// validateSwapAssignments validates the assignments themselves.
-func (h *Handler) validateSwapAssignments(ctx context.Context, requesterAssignmentID, targetAssignmentID, userID string) string {
-	reqAssignment, err := h.db.GetAssignmentByID(ctx, requesterAssignmentID)
-	if err != nil {
+	case errors.Is(err, database.ErrRequesterAssignmentNotFound):
 		return "Your assignment was not found."
-	}
-
-	tgtAssignment, err := h.db.GetAssignmentByID(ctx, targetAssignmentID)
-	if err != nil {
+	case errors.Is(err, database.ErrTargetAssignmentNotFound):
 		return "Target assignment was not found."
-	}
-
-	if reqAssignment.MemberID != userID {
+	case errors.Is(err, database.ErrSwapNotOwner):
 		return "You can only swap your own assignments."
-	}
-
-	if tgtAssignment.MemberID == reqAssignment.MemberID {
+	case errors.Is(err, database.ErrSwapTargetSelf):
 		return "You can only request swaps with another member."
+	case errors.Is(err, database.ErrSwapRequesterDatePassed):
+		return "Your HAT day has already passed and cannot be swapped."
+	case errors.Is(err, database.ErrSwapTargetDatePassed):
+		return "The target HAT day has already passed and cannot be swapped."
+	default:
+		return err.Error()
 	}
-
-	nowUTC := time.Now().UTC()
-	today := time.Date(nowUTC.Year(), nowUTC.Month(), nowUTC.Day(), 0, 0, 0, 0, time.UTC)
-
-	reqDate, err := time.Parse("2006-01-02", reqAssignment.Date)
-	if err != nil {
-		return "Invalid date on your assignment."
-	}
-
-	tgtDate, err := time.Parse("2006-01-02", tgtAssignment.Date)
-	if err != nil {
-		return "Invalid date on target assignment."
-	}
-
-	if dateErr := validateSwapDates(reqDate, tgtDate, today); dateErr != nil {
-		return dateErr.Error()
-	}
-
-	return ""
 }
 
 func (h *Handler) handleSwapCancel(w http.ResponseWriter, r *http.Request) {
@@ -188,12 +137,12 @@ func (h *Handler) handleSwapCancel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if swap.Status != swapStatusPending {
+	if swap.Status != database.SwapStatusPending {
 		http.Error(w, "swap is no longer pending", http.StatusBadRequest)
 		return
 	}
 
-	if err := h.db.UpdateHatSwapStatus(ctx, swapID, swapStatusCancelled); err != nil {
+	if err := h.db.UpdateHatSwapStatus(ctx, swapID, database.SwapStatusCancelled); err != nil {
 		if errors.Is(err, database.ErrSwapNotPending) {
 			http.Error(w, "swap is no longer pending", http.StatusConflict)
 			return
@@ -230,7 +179,7 @@ func (h *Handler) handleSwapAccept(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if swap.Status != swapStatusPending {
+	if swap.Status != database.SwapStatusPending {
 		http.Error(w, "swap is no longer pending", http.StatusBadRequest)
 		return
 	}
@@ -272,12 +221,12 @@ func (h *Handler) handleSwapReject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if swap.Status != swapStatusPending {
+	if swap.Status != database.SwapStatusPending {
 		http.Error(w, "swap is no longer pending", http.StatusBadRequest)
 		return
 	}
 
-	if err := h.db.UpdateHatSwapStatus(ctx, swapID, swapStatusRejected); err != nil {
+	if err := h.db.UpdateHatSwapStatus(ctx, swapID, database.SwapStatusRejected); err != nil {
 		if errors.Is(err, database.ErrSwapNotPending) {
 			http.Error(w, "swap is no longer pending", http.StatusConflict)
 			return
@@ -348,7 +297,7 @@ func (h *Handler) loadSwapsData(ctx context.Context, data map[string]any, member
 
 	for i := range swaps {
 		s := &swaps[i]
-		if s.TargetMemberID == memberID && s.Status == swapStatusPending {
+		if s.TargetMemberID == memberID && s.Status == database.SwapStatusPending {
 			incoming = append(incoming, *s)
 		} else {
 			others = append(others, *s)
@@ -379,19 +328,6 @@ func (h *Handler) loadSwapsData(ctx context.Context, data map[string]any, member
 	}
 
 	data["TargetAssignments"] = targetAssignments
-
-	return nil
-}
-
-// validateSwapDates checks that both dates are in the future.
-func validateSwapDates(reqDate, tgtDate, today time.Time) error {
-	if reqDate.Before(today) {
-		return errors.New("your HAT day has already passed and cannot be swapped")
-	}
-
-	if tgtDate.Before(today) {
-		return errors.New("the target HAT day has already passed and cannot be swapped")
-	}
 
 	return nil
 }

--- a/internal/web/swap_handlers.go
+++ b/internal/web/swap_handlers.go
@@ -93,28 +93,28 @@ func (h *Handler) handleSwapRequestPost(w http.ResponseWriter, r *http.Request, 
 
 // swapValidationErrorMessage maps domain errors from ValidateSwapAssignments to user-facing messages.
 func swapValidationErrorMessage(err error) string {
-	switch {
-	case errors.Is(err, database.ErrSwapSameAssignment):
-		return "Cannot swap an assignment with itself."
-	case errors.Is(err, database.ErrRequesterAssignmentNotFound):
-		return "Your assignment was not found."
-	case errors.Is(err, database.ErrTargetAssignmentNotFound):
-		return "Target assignment was not found."
-	case errors.Is(err, database.ErrSwapNotOwner):
-		return "You can only swap your own assignments."
-	case errors.Is(err, database.ErrSwapTargetSelf):
-		return "You can only request swaps with another member."
-	case errors.Is(err, database.ErrSwapRequesterDatePassed):
-		return "Your HAT day has already passed and cannot be swapped."
-	case errors.Is(err, database.ErrSwapTargetDatePassed):
-		return "The target HAT day has already passed and cannot be swapped."
-	case errors.Is(err, database.ErrSwapRequesterDateInvalid):
-		return "Your assignment date is invalid."
-	case errors.Is(err, database.ErrSwapTargetDateInvalid):
-		return "The target assignment date is invalid."
-	default:
-		return "An unexpected error occurred."
+	errorMessages := []struct {
+		target error
+		msg    string
+	}{
+		{database.ErrSwapSameAssignment, "Cannot swap an assignment with itself."},
+		{database.ErrRequesterAssignmentNotFound, "Your assignment was not found."},
+		{database.ErrTargetAssignmentNotFound, "Target assignment was not found."},
+		{database.ErrSwapNotOwner, "You can only swap your own assignments."},
+		{database.ErrSwapTargetSelf, "You can only request swaps with another member."},
+		{database.ErrSwapRequesterDatePassed, "Your HAT day has already passed and cannot be swapped."},
+		{database.ErrSwapTargetDatePassed, "The target HAT day has already passed and cannot be swapped."},
+		{database.ErrSwapRequesterDateInvalid, "Your assignment date is invalid."},
+		{database.ErrSwapTargetDateInvalid, "The target assignment date is invalid."},
 	}
+
+	for _, em := range errorMessages {
+		if errors.Is(err, em.target) {
+			return em.msg
+		}
+	}
+
+	return "An unexpected error occurred."
 }
 
 func (h *Handler) handleSwapCancel(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/swap_handlers.go
+++ b/internal/web/swap_handlers.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/inful/madhatter/internal/auth"
 	"github.com/inful/madhatter/internal/database"
 )
 
@@ -24,11 +23,7 @@ func (h *Handler) resolveMemberID(ctx context.Context, email string) string {
 func (h *Handler) handleSwaps(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	user, ok := auth.GetUserFromContext(ctx)
-	if !ok {
-		http.Redirect(w, r, "/login", http.StatusSeeOther)
-		return
-	}
+	user := mustGetUser(ctx)
 
 	memberID := h.resolveMemberID(ctx, user.Email)
 
@@ -116,12 +111,7 @@ func swapValidationErrorMessage(err error) string {
 func (h *Handler) handleSwapCancel(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	user, ok := auth.GetUserFromContext(ctx)
-	if !ok {
-		http.Redirect(w, r, "/login", http.StatusSeeOther)
-		return
-	}
-
+	user := mustGetUser(ctx)
 	memberID := h.resolveMemberID(ctx, user.Email)
 
 	swapID := chi.URLParam(r, "id")
@@ -158,12 +148,7 @@ func (h *Handler) handleSwapCancel(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleSwapAccept(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	user, ok := auth.GetUserFromContext(ctx)
-	if !ok {
-		http.Redirect(w, r, "/login", http.StatusSeeOther)
-		return
-	}
-
+	user := mustGetUser(ctx)
 	memberID := h.resolveMemberID(ctx, user.Email)
 
 	swapID := chi.URLParam(r, "id")
@@ -200,12 +185,7 @@ func (h *Handler) handleSwapAccept(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleSwapReject(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	user, ok := auth.GetUserFromContext(ctx)
-	if !ok {
-		http.Redirect(w, r, "/login", http.StatusSeeOther)
-		return
-	}
-
+	user := mustGetUser(ctx)
 	memberID := h.resolveMemberID(ctx, user.Email)
 
 	swapID := chi.URLParam(r, "id")
@@ -242,11 +222,7 @@ func (h *Handler) handleSwapReject(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleSwapAdminDelete(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	user, ok := auth.GetUserFromContext(ctx)
-	if !ok {
-		http.Redirect(w, r, "/login", http.StatusSeeOther)
-		return
-	}
+	user := mustGetUser(ctx)
 
 	if !user.IsAdmin.Valid || user.IsAdmin.Int64 != 1 {
 		http.Error(w, "forbidden", http.StatusForbidden)

--- a/internal/web/swap_handlers_test.go
+++ b/internal/web/swap_handlers_test.go
@@ -109,7 +109,7 @@ func TestSwapValidationErrorMessage_KnownErrors(t *testing.T) {
 // handleSwaps GET
 // ---------------------------------------------------------------------------
 
-func TestHandleSwaps_NoAuth_Redirects(t *testing.T) {
+func TestHandleSwaps_NoAuth_Panics(t *testing.T) {
 	db, cleanup := setupSwapTestDB(t)
 	defer cleanup()
 
@@ -118,10 +118,11 @@ func TestHandleSwaps_NoAuth_Redirects(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/swaps", nil)
 	w := httptest.NewRecorder()
 
-	h.handleSwaps(w, req)
-
-	assert.Equal(t, http.StatusSeeOther, w.Code)
-	assert.Equal(t, "/login", w.Header().Get("Location"))
+	// safeRequireAuth middleware guarantees user is in context before the handler
+	// runs. Calling the handler without it is a programming error and must panic.
+	assert.Panics(t, func() {
+		h.handleSwaps(w, req)
+	})
 }
 
 func TestHandleSwaps_NotATeamMember_ShowsError(t *testing.T) {
@@ -382,7 +383,7 @@ func TestHandleSwaps_GetPendingOutgoingSwap_ShowsCancelButton(t *testing.T) {
 // handleSwapCancel
 // ---------------------------------------------------------------------------
 
-func TestHandleSwapCancel_NoAuth_Redirects(t *testing.T) {
+func TestHandleSwapCancel_NoAuth_Panics(t *testing.T) {
 	db, cleanup := setupSwapTestDB(t)
 	defer cleanup()
 
@@ -392,10 +393,9 @@ func TestHandleSwapCancel_NoAuth_Redirects(t *testing.T) {
 	req = withChiParam(req, "some-id")
 	w := httptest.NewRecorder()
 
-	h.handleSwapCancel(w, req)
-
-	assert.Equal(t, http.StatusSeeOther, w.Code)
-	assert.Equal(t, "/login", w.Header().Get("Location"))
+	assert.Panics(t, func() {
+		h.handleSwapCancel(w, req)
+	})
 }
 
 func TestHandleSwapCancel_SwapNotFound_404(t *testing.T) {
@@ -538,7 +538,7 @@ func TestHandleSwapCancel_Valid_Redirects(t *testing.T) {
 // handleSwapAccept
 // ---------------------------------------------------------------------------
 
-func TestHandleSwapAccept_NoAuth_Redirects(t *testing.T) {
+func TestHandleSwapAccept_NoAuth_Panics(t *testing.T) {
 	db, cleanup := setupSwapTestDB(t)
 	defer cleanup()
 
@@ -548,10 +548,9 @@ func TestHandleSwapAccept_NoAuth_Redirects(t *testing.T) {
 	req = withChiParam(req, "some-id")
 	w := httptest.NewRecorder()
 
-	h.handleSwapAccept(w, req)
-
-	assert.Equal(t, http.StatusSeeOther, w.Code)
-	assert.Equal(t, "/login", w.Header().Get("Location"))
+	assert.Panics(t, func() {
+		h.handleSwapAccept(w, req)
+	})
 }
 
 func TestHandleSwapAccept_NotTarget_403(t *testing.T) {
@@ -761,7 +760,7 @@ func TestHandleSwapReject_Valid_SetsStatusAndRedirects(t *testing.T) {
 // handleSwapAdminDelete
 // ---------------------------------------------------------------------------
 
-func TestHandleSwapAdminDelete_NoAuth_Redirects(t *testing.T) {
+func TestHandleSwapAdminDelete_NoAuth_Panics(t *testing.T) {
 	db, cleanup := setupSwapTestDB(t)
 	defer cleanup()
 
@@ -771,9 +770,9 @@ func TestHandleSwapAdminDelete_NoAuth_Redirects(t *testing.T) {
 	req = withChiParam(req, "some-id")
 	w := httptest.NewRecorder()
 
-	h.handleSwapAdminDelete(w, req)
-
-	assert.Equal(t, http.StatusSeeOther, w.Code)
+	assert.Panics(t, func() {
+		h.handleSwapAdminDelete(w, req)
+	})
 }
 
 func TestHandleSwapAdminDelete_NonAdmin_403(t *testing.T) {

--- a/internal/web/swap_handlers_test.go
+++ b/internal/web/swap_handlers_test.go
@@ -97,6 +97,8 @@ func TestSwapValidationErrorMessage_KnownErrors(t *testing.T) {
 		{database.ErrSwapTargetSelf, "another member"},
 		{database.ErrSwapRequesterDatePassed, "HAT day"},
 		{database.ErrSwapTargetDatePassed, "target HAT day"},
+		{database.ErrSwapRequesterDateInvalid, "invalid"},
+		{database.ErrSwapTargetDateInvalid, "invalid"},
 	}
 
 	for _, tc := range cases {

--- a/internal/web/swap_handlers_test.go
+++ b/internal/web/swap_handlers_test.go
@@ -82,35 +82,27 @@ func seedSchedule(t *testing.T, db *database.DB) {
 }
 
 // ---------------------------------------------------------------------------
-// validateSwapDates — pure function tests
+// swapValidationErrorMessage — error mapping tests
 // ---------------------------------------------------------------------------
 
-func TestValidateSwapDates_BothFuture(t *testing.T) {
-	today := time.Now().Truncate(24 * time.Hour)
-	tomorrow := today.AddDate(0, 0, 1)
-	dayAfter := today.AddDate(0, 0, 2)
+func TestSwapValidationErrorMessage_KnownErrors(t *testing.T) {
+	cases := []struct {
+		err      error
+		contains string
+	}{
+		{database.ErrSwapSameAssignment, "itself"},
+		{database.ErrRequesterAssignmentNotFound, "not found"},
+		{database.ErrTargetAssignmentNotFound, "not found"},
+		{database.ErrSwapNotOwner, "your own"},
+		{database.ErrSwapTargetSelf, "another member"},
+		{database.ErrSwapRequesterDatePassed, "HAT day"},
+		{database.ErrSwapTargetDatePassed, "target HAT day"},
+	}
 
-	require.NoError(t, validateSwapDates(tomorrow, dayAfter, today))
-}
-
-func TestValidateSwapDates_RequesterDatePast(t *testing.T) {
-	today := time.Now().Truncate(24 * time.Hour)
-	yesterday := today.AddDate(0, 0, -1)
-	tomorrow := today.AddDate(0, 0, 1)
-
-	err := validateSwapDates(yesterday, tomorrow, today)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "your HAT day has already passed")
-}
-
-func TestValidateSwapDates_TargetDatePast(t *testing.T) {
-	today := time.Now().Truncate(24 * time.Hour)
-	tomorrow := today.AddDate(0, 0, 1)
-	yesterday := today.AddDate(0, 0, -1)
-
-	err := validateSwapDates(tomorrow, yesterday, today)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "the target HAT day has already passed")
+	for _, tc := range cases {
+		msg := swapValidationErrorMessage(tc.err)
+		assert.Contains(t, msg, tc.contains, "error: %v", tc.err)
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Move duplicated swap validation logic from web and API handlers into the database layer:

- Add exported SwapStatus* constants (pending, accepted, rejected, cancelled) to replace local string constants in both handlers
- Add sentinel errors for each validation case (ErrSwapSameAssignment, ErrSwapNotOwner, ErrSwapTargetSelf, ErrRequesterAssignmentNotFound, ErrTargetAssignmentNotFound, ErrSwapRequesterDatePassed, ErrSwapTargetDatePassed)
- Add DB.ValidateSwapAssignments to enforce ownership, membership and date constraints in one place
- Add DB.CheckNoOpenSwaps to detect conflicting pending swaps
- Simplify web handler: inline validation using shared methods, eliminating redundant double-fetch of assignments
- Simplify API handler: delegate to shared methods and map domain errors to HTTP status codes via swapDomainToHumaError
- Update tests: replace validateSwapDates unit tests with tests for the swapValidationErrorMessage error-mapping function